### PR TITLE
Stabilize tab layout sizing and unify menu bar styles

### DIFF
--- a/Sources/ClashBar/App/StatusItem/StatusItemContentView.swift
+++ b/Sources/ClashBar/App/StatusItem/StatusItemContentView.swift
@@ -7,7 +7,7 @@ final class StatusItemContentView: NSView {
     }
 
     // Keep a 1pt optical inset to stabilize status-item width across icon/text mode switches.
-    private let statusItemHorizontalPadding: CGFloat = MenuBarLayoutTokens.opticalNudge
+    private let statusItemHorizontalPadding: CGFloat = MenuBarLayoutTokens.space1
     private let iconSize: CGFloat = 24
     private let brandIconRenderSize: CGFloat = 24
     private let symbolPointSize: CGFloat = 20

--- a/Sources/ClashBar/App/StatusItem/StatusItemController.swift
+++ b/Sources/ClashBar/App/StatusItem/StatusItemController.swift
@@ -39,7 +39,7 @@ final class StatusItemController: NSObject {
     private let popoverFallbackMaxHeight: CGFloat = 640
     private let popoverScreenPadding: CGFloat = 10
     private let panelTopSpacing: CGFloat = 0
-    private let panelHorizontalPadding: CGFloat = MenuBarLayoutTokens.hPage
+    private let panelHorizontalPadding: CGFloat = MenuBarLayoutTokens.space8
 
     private var changeCancellable: AnyCancellable?
     private var layoutCancellable: AnyCancellable?

--- a/Sources/ClashBar/Features/MenuBar/Components/AttachedPopoverMenu.swift
+++ b/Sources/ClashBar/Features/MenuBar/Components/AttachedPopoverMenu.swift
@@ -1,9 +1,9 @@
 import AppKit
 import SwiftUI
 
-struct AttachedPopoverMenu<Label: View, Content: View>: View {
-    @Environment(\.panelMeasurementMode) private var panelMeasurementMode
+private typealias T = MenuBarLayoutTokens
 
+struct AttachedPopoverMenu<Label: View, Content: View>: View {
     let width: CGFloat?
     let maxHeight: CGFloat?
     let onWillPresent: (() -> Void)?
@@ -29,33 +29,29 @@ struct AttachedPopoverMenu<Label: View, Content: View>: View {
     }
 
     var body: some View {
-        if self.panelMeasurementMode {
+        Button(action: self.activateAnchor) {
             self.anchorLabel
-        } else {
-            Button(action: self.activateAnchor) {
-                self.anchorLabel
-            }
-            .buttonStyle(.plain)
-            .onHover { hovering in
-                if hovering, !self.suppressAutoOpen {
-                    self.requestOpen()
-                }
-                self.isAnchorHovered = hovering
-                if !hovering {
-                    self.suppressAutoOpen = false
-                }
-            }
-            .background(
-                SideAttachedPopoverHost(
-                    anchorHovered: self.$isAnchorHovered,
-                    suppressAutoOpen: self.$suppressAutoOpen,
-                    width: self.width,
-                    maxHeight: self.maxHeight,
-                    onVisibilityChanged: { visible in
-                        self.shouldBuildPopoverContent = visible
-                    },
-                    content: self.popoverContent))
         }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering, !self.suppressAutoOpen {
+                self.requestOpen()
+            }
+            self.isAnchorHovered = hovering
+            if !hovering {
+                self.suppressAutoOpen = false
+            }
+        }
+        .background(
+            SideAttachedPopoverHost(
+                anchorHovered: self.$isAnchorHovered,
+                suppressAutoOpen: self.$suppressAutoOpen,
+                width: self.width,
+                maxHeight: self.maxHeight,
+                onVisibilityChanged: { visible in
+                    self.shouldBuildPopoverContent = visible
+                },
+                content: self.popoverContent))
     }
 
     var anchorLabel: some View {
@@ -77,15 +73,19 @@ struct AttachedPopoverMenu<Label: View, Content: View>: View {
             .scrollIndicators(.hidden)
             .frame(width: self.width, alignment: .leading)
             .frame(maxHeight: self.maxHeight)
-            .padding(8)
+            .padding(T.space8)
             .background(
-                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous)
+                RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
                     .fill(.regularMaterial))
             .overlay {
-                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous)
-                    .stroke(Color(nsColor: .separatorColor).opacity(0.46), lineWidth: 0.65)
+                RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.46), lineWidth: T.stroke)
             }
-            .shadow(color: Color(nsColor: .shadowColor).opacity(0.20), radius: 12, x: 0, y: 6)
+            .shadow(
+                color: Color(nsColor: .shadowColor).opacity(T.Shadow.standard.opacity),
+                radius: T.Shadow.standard.radius,
+                x: T.Shadow.standard.x,
+                y: T.Shadow.standard.y)
         }
     }
 
@@ -118,22 +118,22 @@ struct AttachedPopoverMenuItem: View {
         Button {
             self.action()
         } label: {
-            HStack(spacing: MenuBarLayoutTokens.hDense) {
+            HStack(spacing: T.space6) {
                 Image(systemName: "checkmark")
-                    .font(.appSystem(size: 10, weight: .semibold))
+                    .font(.app(size: T.FontSize.caption, weight: .semibold))
                     .opacity(self.selected ? 1 : 0)
                     .frame(width: 12, alignment: .center)
                 Text(self.title)
-                    .font(.appSystem(size: 12, weight: .medium))
+                    .font(.app(size: T.FontSize.body, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer(minLength: 0)
             }
             .foregroundStyle(self.itemForeground)
-            .padding(.horizontal, MenuBarLayoutTokens.hDense)
-            .padding(.vertical, MenuBarLayoutTokens.vDense + 1)
+            .padding(.horizontal, T.space6)
+            .padding(.vertical, T.space2)
             .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
                     .fill(self.itemBackground))
             .contentShape(Rectangle())
         }
@@ -156,7 +156,7 @@ struct AttachedPopoverMenuItem: View {
 struct AttachedPopoverMenuDivider: View {
     var body: some View {
         Divider()
-            .padding(.vertical, 2)
+            .padding(.vertical, T.space2)
     }
 }
 

--- a/Sources/ClashBar/Features/MenuBar/Components/MenuBarCommonViews.swift
+++ b/Sources/ClashBar/Features/MenuBar/Components/MenuBarCommonViews.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 struct SeparatedForEach<Element: Equatable, ID: Hashable, RowContent: View>: View {
     private struct Item: Identifiable {
         let id: ID
@@ -31,15 +33,13 @@ struct SeparatedForEach<Element: Equatable, ID: Hashable, RowContent: View>: Vie
             if !item.isLast {
                 Rectangle()
                     .fill(self.separator)
-                    .frame(height: MenuBarLayoutTokens.hairline)
+                    .frame(height: MenuBarLayoutTokens.stroke)
             }
         }
     }
 }
 
 struct MeasurementAwareVStack<Content: View>: View {
-    @Environment(\.panelMeasurementMode) private var panelMeasurementMode
-
     let alignment: HorizontalAlignment
     let spacing: CGFloat
     @ViewBuilder let content: Content
@@ -51,27 +51,23 @@ struct MeasurementAwareVStack<Content: View>: View {
     }
 
     var body: some View {
-        if self.panelMeasurementMode {
-            VStack(alignment: self.alignment, spacing: self.spacing) { self.content }
-        } else {
-            LazyVStack(alignment: self.alignment, spacing: self.spacing) { self.content }
-        }
+        LazyVStack(alignment: self.alignment, spacing: self.spacing) { self.content }
     }
 }
 
 extension MenuBarRoot {
     func fractionSummaryBadge(current: Int, total: Int) -> some View {
-        HStack(spacing: MenuBarLayoutTokens.hMicro) {
+        HStack(spacing: MenuBarLayoutTokens.space1) {
             Text("\(current)")
-                .font(.appMonospaced(size: 11, weight: .bold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .bold))
             Text("/")
-                .font(.appMonospaced(size: 10, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
             Text("\(total)")
-                .font(.appMonospaced(size: 11, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
         }
         .foregroundStyle(self.nativeSecondaryLabel)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
+        .padding(.horizontal, MenuBarLayoutTokens.space6)
+        .padding(.vertical, MenuBarLayoutTokens.space2)
         .background(self.nativeBadgeCapsule())
     }
 
@@ -98,7 +94,7 @@ extension MenuBarRoot {
             }
         } label: {
             Label(optionTitle(selection), systemImage: symbol)
-                .font(.appSystem(size: 11, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                 .lineLimit(1)
         }
         .buttonStyle(.bordered)
@@ -147,35 +143,35 @@ extension MenuBarRoot {
     }
 
     var nativeSecondaryLabel: Color {
-        Color(nsColor: .labelColor).opacity(self.isDarkAppearance ? 0.88 : 0.80)
+        Color(nsColor: .labelColor).opacity(self.isDarkAppearance ? T.Theme.Dark.labelSecondary : T.Theme.Light.labelSecondary)
     }
 
     var nativeTertiaryLabel: Color {
-        Color(nsColor: .labelColor).opacity(self.isDarkAppearance ? 0.72 : 0.64)
+        Color(nsColor: .labelColor).opacity(self.isDarkAppearance ? T.Theme.Dark.labelTertiary : T.Theme.Light.labelTertiary)
     }
 
     var nativeSeparator: Color {
-        Color(nsColor: .separatorColor).opacity(self.isDarkAppearance ? 0.70 : 0.55)
+        Color(nsColor: .separatorColor).opacity(self.isDarkAppearance ? T.Theme.Dark.separator : T.Theme.Light.separator)
     }
 
     var nativeControlFill: Color {
         Color(nsColor: self.isDarkAppearance ? .controlBackgroundColor : .windowBackgroundColor)
-            .opacity(self.isDarkAppearance ? 0.78 : 0.92)
+            .opacity(self.isDarkAppearance ? T.Theme.Dark.controlFill : T.Theme.Light.controlFill)
     }
 
     var nativeControlBorder: Color {
-        Color(nsColor: .separatorColor).opacity(self.isDarkAppearance ? 0.60 : 0.42)
+        Color(nsColor: .separatorColor).opacity(self.isDarkAppearance ? T.Theme.Dark.controlBorder : T.Theme.Light.controlBorder)
     }
 
     var nativeHoverFill: Color {
-        Color(nsColor: .selectedContentBackgroundColor).opacity(self.isDarkAppearance ? 0.28 : 0.20)
+        Color(nsColor: .selectedContentBackgroundColor).opacity(self.isDarkAppearance ? T.Theme.Dark.hoverFill : T.Theme.Light.hoverFill)
     }
 
     var nativeBadgeFill: Color {
-        Color(nsColor: .quaternaryLabelColor).opacity(self.isDarkAppearance ? 0.30 : 0.16)
+        Color(nsColor: .quaternaryLabelColor).opacity(MenuBarLayoutTokens.Opacity.tint)
     }
 
-    func nativeHoverRowBackground(_ hovered: Bool, cornerRadius: CGFloat = 6) -> some View {
+    func nativeHoverRowBackground(_ hovered: Bool, cornerRadius: CGFloat = MenuBarLayoutTokens.cornerRadius) -> some View {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
             .fill(hovered ? self.nativeHoverFill : .clear)
     }
@@ -187,7 +183,7 @@ extension MenuBarRoot {
 
     func emptyCard(_ text: String) -> some View {
         Text(text)
-            .font(.appSystem(size: 12, weight: .regular))
+            .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .regular))
             .foregroundStyle(self.nativeSecondaryLabel)
             .frame(maxWidth: .infinity, alignment: .leading)
             .menuRowPadding()
@@ -198,7 +194,7 @@ extension MenuBarRoot {
         let mihomoSymbol = "antenna.radiowaves.left.and.right"
 
         return VStack(spacing: 0) {
-            HStack(spacing: MenuBarLayoutTokens.hDense) {
+            HStack(spacing: MenuBarLayoutTokens.space6) {
                 self.footerInfo(
                     tr("ui.footer.core_mihomo", appState.version),
                     url: mihomoRepositoryURL,
@@ -209,7 +205,7 @@ extension MenuBarRoot {
                 self.footerVersionInfo
                     .fixedSize(horizontal: true, vertical: false)
             }
-            .menuRowPadding(vertical: MenuBarLayoutTokens.vDense)
+            .menuRowPadding(vertical: MenuBarLayoutTokens.space2)
             .background(self.footerSurfaceBackground)
         }
         .task {
@@ -218,13 +214,17 @@ extension MenuBarRoot {
     }
 
     var footerSurfaceBackground: some View {
-        RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous)
+        RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
             .fill(self.nativeControlFill.opacity(0.86))
             .overlay {
-                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous)
-                    .stroke(self.nativeControlBorder.opacity(0.9), lineWidth: 0.6)
+                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
+                    .stroke(self.nativeControlBorder.opacity(MenuBarLayoutTokens.Opacity.solid), lineWidth: MenuBarLayoutTokens.stroke)
             }
-            .shadow(color: Color(nsColor: .shadowColor).opacity(0.16), radius: 10, x: 0, y: -3)
+            .shadow(
+                color: Color(nsColor: .shadowColor).opacity(MenuBarLayoutTokens.Shadow.standard.opacity),
+                radius: MenuBarLayoutTokens.Shadow.standard.radius,
+                x: MenuBarLayoutTokens.Shadow.standard.x,
+                y: MenuBarLayoutTokens.Shadow.standard.y)
     }
 
     @ViewBuilder
@@ -240,19 +240,19 @@ extension MenuBarRoot {
     }
 
     func footerInfoLabel(_ text: String, iconSystemName: String?) -> some View {
-        HStack(spacing: 4) {
+        HStack(spacing: MenuBarLayoutTokens.space4) {
             if let iconSystemName {
                 Image(systemName: iconSystemName)
-                    .font(.appSystem(size: 10, weight: .semibold))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                     .foregroundStyle(self.nativeSecondaryLabel)
             }
 
             Text(text)
-                .font(.appSystem(size: 11, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                 .foregroundStyle(self.nativeSecondaryLabel)
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .minimumScaleFactor(0.85)
+                .minimumScaleFactor(MenuBarLayoutTokens.minimumScale)
                 .allowsTightening(true)
         }
         .help(text)
@@ -279,35 +279,35 @@ extension MenuBarRoot {
     }
 
     func footerVersionUpdateLabel(_ release: AppReleaseInfo) -> some View {
-        HStack(spacing: 4) {
+        HStack(spacing: MenuBarLayoutTokens.space4) {
             Image(systemName: "arrow.down.circle.fill")
-                .font(.appSystem(size: 10, weight: .semibold))
-                .foregroundStyle(self.nativeAccent.opacity(0.95))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
+                .foregroundStyle(self.nativeAccent.opacity(MenuBarLayoutTokens.Opacity.solid))
 
             Text(tr("ui.footer.version", self.appState.currentAppVersionText))
-                .font(.appSystem(size: 11, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                 .foregroundStyle(self.nativeSecondaryLabel)
                 .lineLimit(1)
-                .minimumScaleFactor(0.85)
+                .minimumScaleFactor(MenuBarLayoutTokens.minimumScale)
 
             Text(release.displayVersion)
-                .font(.appMonospaced(size: 10, weight: .bold))
-                .foregroundStyle(self.nativeAccent.opacity(0.95))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .bold))
+                .foregroundStyle(self.nativeAccent.opacity(MenuBarLayoutTokens.Opacity.solid))
                 .lineLimit(1)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 1)
+                .padding(.horizontal, MenuBarLayoutTokens.space4)
+                .padding(.vertical, MenuBarLayoutTokens.space1)
                 .background(
                     Capsule(style: .continuous)
-                        .fill(self.nativeAccent.opacity(self.isDarkAppearance ? 0.24 : 0.14)))
+                        .fill(self.nativeAccent.opacity(MenuBarLayoutTokens.Opacity.tint)))
         }
     }
 
     var statusColor: Color {
         switch appState.runtimeVisualStatus {
-        case .runningHealthy: self.nativePositive.opacity(0.95)
-        case .runningDegraded: self.nativeWarning.opacity(0.95)
-        case .starting: self.nativeInfo.opacity(0.95)
-        case .failed: self.nativeCritical.opacity(0.95)
+        case .runningHealthy: self.nativePositive.opacity(MenuBarLayoutTokens.Opacity.solid)
+        case .runningDegraded: self.nativeWarning.opacity(MenuBarLayoutTokens.Opacity.solid)
+        case .starting: self.nativeInfo.opacity(MenuBarLayoutTokens.Opacity.solid)
+        case .failed: self.nativeCritical.opacity(MenuBarLayoutTokens.Opacity.solid)
         case .stopped: self.nativeSecondaryLabel
         }
     }
@@ -377,9 +377,9 @@ extension MenuBarRoot {
         guard let value else {
             return self.nativeTertiaryLabel
         }
-        if value == 0 { return self.nativeCritical.opacity(0.9) }
-        if value <= 400 { return self.nativePositive.opacity(0.9) }
-        return self.nativeWarning.opacity(0.9)
+        if value == 0 { return self.nativeCritical.opacity(MenuBarLayoutTokens.Opacity.solid) }
+        if value <= 400 { return self.nativePositive.opacity(MenuBarLayoutTokens.Opacity.solid) }
+        return self.nativeWarning.opacity(MenuBarLayoutTokens.Opacity.solid)
     }
 
     func sortedGroupNodes(_ group: ProxyGroup) -> [String] {
@@ -407,7 +407,7 @@ extension MenuBarRoot {
         role: ButtonRole? = nil,
         isLoading: Bool = false,
         size: CGFloat = 20,
-        fontSize: CGFloat = 13,
+        fontSize: CGFloat = MenuBarLayoutTokens.FontSize.body,
         hierarchicalSymbol: Bool = false,
         action: @escaping () async -> Void) -> some View
     {
@@ -444,7 +444,7 @@ private struct CompactAsyncIconButton: View {
         } label: {
             ZStack {
                 Image(systemName: self.symbol)
-                    .font(.appSystem(size: self.fontSize, weight: .semibold))
+                    .font(.app(size: self.fontSize, weight: .semibold))
                     .foregroundStyle(self.hovered ? self.tint : self.baseTint)
                     .symbolRenderingMode(self.hierarchicalSymbol ? .hierarchical : .monochrome)
                     .opacity(self.isLoading ? 0 : 1)

--- a/Sources/ClashBar/Features/MenuBar/Components/SparklineView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Components/SparklineView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 struct TrafficSparklineView: View {
     let upValues: [Int64]
     let downValues: [Int64]
@@ -34,7 +36,7 @@ struct TrafficSparklineView: View {
                 self.axisPath(width: geo.size.width, axisY: axisY)
                     .stroke(
                         Color(nsColor: .separatorColor).opacity(0.55),
-                        style: StrokeStyle(lineWidth: 0.7, lineCap: .round))
+                        style: StrokeStyle(lineWidth: T.stroke, lineCap: .round))
 
                 self.lineAreaPath(for: normalizedUp, context: upContext)
                     .fill(

--- a/Sources/ClashBar/Features/MenuBar/Layout/MenuBarLayoutTokens.swift
+++ b/Sources/ClashBar/Features/MenuBar/Layout/MenuBarLayoutTokens.swift
@@ -3,29 +3,85 @@ import SwiftUI
 enum MenuBarLayoutTokens {
     static let panelWidth: CGFloat = 360
 
-    static let hPage: CGFloat = 8
-    static let hRow: CGFloat = 4
-    static let hDense: CGFloat = 6
-    static let hMicro: CGFloat = 3
+    // MARK: - Spacing
 
-    static let vRow: CGFloat = 6
-    static let vDense: CGFloat = 3
-    static let sectionGap: CGFloat = 6
+    static let space1: CGFloat = 1
+    static let space2: CGFloat = 2
+    static let space4: CGFloat = 4
+    static let space6: CGFloat = 6
+    static let space8: CGFloat = 8
 
-    static let hairline: CGFloat = 0.6
-    static let opticalNudge: CGFloat = 1
+    // MARK: - Stroke
 
-    static let panelCornerRadius: CGFloat = 16
-    static let cardCornerRadius: CGFloat = 8
-    static let iconCornerRadius: CGFloat = 6
+    static let stroke: CGFloat = 0.65
 
-    static let rowLeadingIconSize: CGFloat = 16
-    static let rowLeadingIconColumnWidth: CGFloat = 16
+    // MARK: - Corner Radius
+
+    static let cornerRadius: CGFloat = 6
+
+    // MARK: - Row Heights
+
+    static let compactRowHeight: CGFloat = 20
+    static let rowHeight: CGFloat = 32
+
+    // MARK: - Icon Size
+
+    static let rowLeadingIcon: CGFloat = 16
+
+    // MARK: - Text
+
+    static let minimumScale: CGFloat = 0.85
+
+    // MARK: - Opacity
+
+    enum Opacity {
+        static let solid: CGFloat = 0.92
+        static let tint: CGFloat = 0.18
+    }
+
+    // MARK: - Theme Appearance
+
+    enum Theme {
+        enum Dark {
+            static let labelSecondary: CGFloat = 0.88
+            static let labelTertiary: CGFloat = 0.72
+            static let separator: CGFloat = 0.70
+            static let controlFill: CGFloat = 0.78
+            static let controlBorder: CGFloat = 0.60
+            static let hoverFill: CGFloat = 0.28
+            static let borderEmphasis: CGFloat = 0.82
+        }
+
+        enum Light {
+            static let labelSecondary: CGFloat = 0.80
+            static let labelTertiary: CGFloat = 0.64
+            static let separator: CGFloat = 0.55
+            static let controlFill: CGFloat = 0.92
+            static let controlBorder: CGFloat = 0.42
+            static let hoverFill: CGFloat = 0.18
+            static let borderEmphasis: CGFloat = 0.82
+        }
+    }
+
+    // MARK: - Shadow
+
+    enum Shadow {
+        static let standard = (opacity: 0.20, radius: 12.0, x: 0.0, y: 6.0)
+    }
+
+    // MARK: - Font Sizes
+
+    enum FontSize {
+        static let caption: CGFloat = 10
+        static let body: CGFloat = 12
+        static let subhead: CGFloat = 14
+        static let title: CGFloat = 16
+    }
 }
 
 extension View {
-    func menuRowPadding(vertical: CGFloat = MenuBarLayoutTokens.vRow) -> some View {
-        padding(.horizontal, MenuBarLayoutTokens.hRow)
+    func menuRowPadding(vertical: CGFloat = MenuBarLayoutTokens.space6) -> some View {
+        padding(.horizontal, MenuBarLayoutTokens.space4)
             .padding(.vertical, vertical)
     }
 }

--- a/Sources/ClashBar/Features/MenuBar/Layout/PanelMeasurementMode.swift
+++ b/Sources/ClashBar/Features/MenuBar/Layout/PanelMeasurementMode.swift
@@ -1,5 +1,0 @@
-import SwiftUI
-
-extension EnvironmentValues {
-    @Entry var panelMeasurementMode: Bool = false
-}

--- a/Sources/ClashBar/Features/MenuBar/Root/MenuBarRoot+Header.swift
+++ b/Sources/ClashBar/Features/MenuBar/Root/MenuBarRoot+Header.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 extension MenuBarRoot {
     var topHeader: some View {
-        HStack(alignment: .center, spacing: 10) {
-            HStack(alignment: .center, spacing: 10) {
+        HStack(alignment: .center, spacing: MenuBarLayoutTokens.space8) {
+            HStack(alignment: .center, spacing: MenuBarLayoutTokens.space8) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
-                        .fill(nativeControlFill.opacity(0.94))
+                    RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
+                        .fill(nativeControlFill.opacity(MenuBarLayoutTokens.Opacity.solid))
                         .overlay {
-                            RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
-                                .stroke(nativeControlBorder.opacity(0.92), lineWidth: 0.7)
+                            RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
+                                .stroke(nativeControlBorder.opacity(MenuBarLayoutTokens.Opacity.solid), lineWidth: MenuBarLayoutTokens.stroke)
                         }
 
                     if let brandImage = BrandIcon.image {
@@ -17,42 +17,42 @@ extension MenuBarRoot {
                             .resizable()
                             .interpolation(.high)
                             .scaledToFit()
-                            .frame(width: 32, height: 32)
+                            .frame(width: MenuBarLayoutTokens.rowHeight, height: MenuBarLayoutTokens.rowHeight)
                     } else {
                         Image(systemName: "paperplane.fill")
                             .renderingMode(.template)
                             .symbolRenderingMode(.monochrome)
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 32, height: 32)
+                            .frame(width: MenuBarLayoutTokens.rowHeight, height: MenuBarLayoutTokens.rowHeight)
                             .foregroundStyle(nativeAccent)
                     }
                 }
-                .frame(width: 32, height: 32)
+                .frame(width: MenuBarLayoutTokens.rowHeight, height: MenuBarLayoutTokens.rowHeight)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 7) {
+                VStack(alignment: .leading, spacing: MenuBarLayoutTokens.space4) {
+                    HStack(spacing: MenuBarLayoutTokens.space6) {
                         Text("ClashBar")
-                            .font(.appSystem(size: 16, weight: .semibold))
+                            .font(.app(size: MenuBarLayoutTokens.FontSize.title, weight: .semibold))
                             .foregroundStyle(nativePrimaryLabel)
 
-                        HStack(spacing: MenuBarLayoutTokens.hMicro) {
+                        HStack(spacing: MenuBarLayoutTokens.space1) {
                             Circle()
                                 .fill(statusColor)
-                                .frame(width: 5, height: 5)
+                                .frame(width: MenuBarLayoutTokens.space4, height: MenuBarLayoutTokens.space4)
                             Text(runtimeBadgeText)
-                                .font(.appSystem(size: 11, weight: .medium))
+                                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                                 .foregroundStyle(nativeSecondaryLabel)
                         }
-                        .padding(.horizontal, MenuBarLayoutTokens.hDense)
-                        .padding(.vertical, 3)
-                        .background(nativeControlFill.opacity(0.92), in: Capsule())
+                        .padding(.horizontal, MenuBarLayoutTokens.space6)
+                        .padding(.vertical, MenuBarLayoutTokens.space2)
+                        .background(nativeControlFill.opacity(MenuBarLayoutTokens.Opacity.solid), in: Capsule())
                         .overlay {
-                            Capsule().stroke(nativeControlBorder.opacity(0.82), lineWidth: 0.7)
+                            Capsule().stroke(nativeControlBorder.opacity(MenuBarLayoutTokens.Theme.Dark.borderEmphasis), lineWidth: MenuBarLayoutTokens.stroke)
                         }
                     }
 
-                    HStack(spacing: 6) {
+                    HStack(spacing: MenuBarLayoutTokens.space6) {
                         self.headerControllerLink(
                             symbol: "network",
                             text: appState.externalControllerDisplay)
@@ -63,9 +63,9 @@ extension MenuBarRoot {
                 }
             }
 
-            Spacer(minLength: 6)
+            Spacer(minLength: MenuBarLayoutTokens.space6)
 
-            HStack(spacing: 6) {
+            HStack(spacing: MenuBarLayoutTokens.space6) {
                 self.compactTopIcon("arrow.clockwise", label: appState.primaryCoreActionLabel) {
                     await appState.performPrimaryCoreAction()
                 }
@@ -90,19 +90,19 @@ extension MenuBarRoot {
                 }
             }
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, MenuBarLayoutTokens.space8)
     }
 
     func headerMetaLabel(symbol: String, text: String) -> some View {
-        HStack(spacing: 4) {
+        HStack(spacing: MenuBarLayoutTokens.space4) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 10, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                 .foregroundStyle(nativeTertiaryLabel)
             Text(text)
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
-        .font(.appSystem(size: 11, weight: .medium))
+        .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
         .foregroundStyle(nativeSecondaryLabel)
     }
 
@@ -124,7 +124,7 @@ extension MenuBarRoot {
 
     var headerControllerWarningIcon: some View {
         Image(systemName: "exclamationmark.triangle.fill")
-            .font(.appSystem(size: 10, weight: .semibold))
+            .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
             .foregroundStyle(nativeWarning)
             .help("external-controller is 0.0.0.0 and can be accessed from your LAN.")
             .accessibilityLabel("Warning: external-controller is bound to 0.0.0.0")
@@ -190,7 +190,7 @@ extension MenuBarRoot {
         return self.compactAsyncIconButton(
             symbol: symbol,
             label: label,
-            tint: tone.opacity(0.94),
+            tint: tone.opacity(MenuBarLayoutTokens.Opacity.solid),
             role: role,
             isLoading: isLoading,
             action: action)

--- a/Sources/ClashBar/Features/MenuBar/Root/MenuBarRoot+ModeTabs.swift
+++ b/Sources/ClashBar/Features/MenuBar/Root/MenuBarRoot+ModeTabs.swift
@@ -3,13 +3,13 @@ import SwiftUI
 
 extension MenuBarRoot {
     var modeAndTabSection: some View {
-        VStack(spacing: MenuBarLayoutTokens.sectionGap) {
+        VStack(spacing: MenuBarLayoutTokens.space6) {
             self.modeSwitcher
             self.topTabs
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(alignment: .bottom) {
-            Rectangle().fill(nativeSeparator).frame(height: MenuBarLayoutTokens.hairline)
+            Rectangle().fill(nativeSeparator).frame(height: MenuBarLayoutTokens.stroke)
         }
     }
 
@@ -28,14 +28,14 @@ extension MenuBarRoot {
                 mode: .direct,
                 symbol: "paperplane")
         }
-        .padding(2)
+        .padding(MenuBarLayoutTokens.space2)
         .frame(width: contentWidth)
         .background(
             nativeControlFill,
-            in: RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous))
+            in: RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous)
-                .stroke(nativeControlBorder, lineWidth: 0.7)
+            RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
+                .stroke(nativeControlBorder, lineWidth: MenuBarLayoutTokens.stroke)
         }
     }
 
@@ -53,34 +53,34 @@ extension MenuBarRoot {
                 switchingMode = nil
             }
         } label: {
-            VStack(spacing: 2) {
+            VStack(spacing: MenuBarLayoutTokens.space2) {
                 if switchingThisMode {
                     ProgressView()
                         .controlSize(.mini)
                 } else {
                     Image(systemName: symbol)
-                        .font(.appSystem(size: 11, weight: .semibold))
+                        .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                 }
 
                 Text(title)
-                    .font(.appSystem(size: 10, weight: .semibold))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                     .lineLimit(1)
             }
             .foregroundStyle((selected || hovered) ? nativePrimaryLabel : nativeSecondaryLabel)
             .frame(maxWidth: .infinity)
-            .frame(height: 34)
+            .frame(height: MenuBarLayoutTokens.rowHeight)
             .background(
-                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
+                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
                     .fill(
                         selected
-                            ? nativeAccent.opacity(0.16)
-                            : (hovered ? Color(nsColor: .selectedContentBackgroundColor).opacity(0.20) : .clear)))
+                            ? nativeAccent.opacity(MenuBarLayoutTokens.Opacity.tint)
+                            : (hovered ? Color(nsColor: .selectedContentBackgroundColor).opacity(MenuBarLayoutTokens.Opacity.tint) : .clear)))
             .overlay {
                 if selected || hovered {
-                    RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
+                    RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
                         .stroke(
-                            selected ? nativeAccent.opacity(0.30) : nativeControlBorder.opacity(0.82),
-                            lineWidth: 0.7)
+                            selected ? nativeAccent.opacity(MenuBarLayoutTokens.Opacity.tint) : nativeControlBorder.opacity(MenuBarLayoutTokens.Theme.Dark.borderEmphasis),
+                            lineWidth: MenuBarLayoutTokens.stroke)
                 }
             }
         }

--- a/Sources/ClashBar/Features/MenuBar/Root/MenuBarRoot.swift
+++ b/Sources/ClashBar/Features/MenuBar/Root/MenuBarRoot.swift
@@ -124,7 +124,6 @@ struct MenuBarRoot: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var popoverLayoutModel: PopoverLayoutModel
     @Environment(\.colorScheme) var colorScheme
-    @Environment(\.panelMeasurementMode) var panelMeasurementMode
 
     @State var currentTab: RootTab = .proxy
     @State var switchingMode: CoreMode?
@@ -151,7 +150,7 @@ struct MenuBarRoot: View {
     @AppStorage("clashbar.proxy.group.hide_hidden") var hideHiddenProxyGroups: Bool = true
 
     var contentWidth: CGFloat {
-        MenuBarLayoutTokens.panelWidth - (MenuBarLayoutTokens.hPage * 2)
+        MenuBarLayoutTokens.panelWidth - (MenuBarLayoutTokens.space8 * 2)
     }
 
     var language: AppLanguage {
@@ -208,10 +207,10 @@ struct MenuBarRoot: View {
                 .reportHeight { updateSectionHeight($0, target: .footer) }
         }
         .frame(width: self.contentWidth, alignment: .topLeading)
-        .padding(.horizontal, MenuBarLayoutTokens.hPage)
+        .padding(.horizontal, MenuBarLayoutTokens.space8)
         .frame(width: MenuBarLayoutTokens.panelWidth, height: resolvedPanelHeight, alignment: .topLeading)
         .background(self.panelBackground)
-        .clipShape(RoundedRectangle(cornerRadius: MenuBarLayoutTokens.panelCornerRadius, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous))
         .onAppear {
             self.setCurrentTabWithoutAnimation(self.appState.activeMenuTab)
             self.appState.setActiveMenuTab(self.currentTab)
@@ -274,18 +273,22 @@ struct MenuBarRoot: View {
 
     func tabContent(for tab: RootTab) -> some View {
         self.tabBody(for: tab)
-            .padding(.top, MenuBarLayoutTokens.vDense)
+            .padding(.top, MenuBarLayoutTokens.space2)
             .fixedSize(horizontal: false, vertical: true)
     }
 
     var panelBackground: some View {
-        RoundedRectangle(cornerRadius: MenuBarLayoutTokens.panelCornerRadius, style: .continuous)
+        RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
             .fill(.regularMaterial)
             .overlay {
-                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.panelCornerRadius, style: .continuous)
-                    .stroke(nativeSeparator, lineWidth: 0.8)
+                RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cornerRadius, style: .continuous)
+                    .stroke(nativeSeparator, lineWidth: MenuBarLayoutTokens.stroke)
             }
-            .shadow(color: Color(nsColor: .shadowColor).opacity(0.28), radius: 18, x: 0, y: 10)
+            .shadow(
+                color: Color(nsColor: .shadowColor).opacity(MenuBarLayoutTokens.Shadow.standard.opacity),
+                radius: MenuBarLayoutTokens.Shadow.standard.radius,
+                x: MenuBarLayoutTokens.Shadow.standard.x,
+                y: MenuBarLayoutTokens.Shadow.standard.y)
     }
 
     func refreshDerivedData(for tab: RootTab) {

--- a/Sources/ClashBar/Features/MenuBar/Tabs/ActivityTabView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/ActivityTabView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 
 extension MenuBarRoot {
     private enum ActivityLayout {
-        static let topLineSpacing: CGFloat = 2
-        static let topMetaSpacing: CGFloat = 1
-        static let secondLineSpacing: CGFloat = 2
-        static let rowLineHeight: CGFloat = 15
+        static let topLineSpacing: CGFloat = MenuBarLayoutTokens.space2
+        static let topMetaSpacing: CGFloat = MenuBarLayoutTokens.space1
+        static let secondLineSpacing: CGFloat = MenuBarLayoutTokens.space2
+        static let rowLineHeight: CGFloat = 16
         static let topRuleMinWidth: CGFloat = 26
         static let topPayloadMinWidth: CGFloat = 14
     }
@@ -26,7 +26,7 @@ extension MenuBarRoot {
     var activityTabBody: some View {
         let connections = self.visibleConnections
 
-        return VStack(alignment: .leading, spacing: MenuBarLayoutTokens.sectionGap) {
+        return VStack(alignment: .leading, spacing: MenuBarLayoutTokens.space6) {
             self.activityControlCard
 
             if connections.isEmpty {
@@ -42,11 +42,10 @@ extension MenuBarRoot {
     }
 
     var activityControlCard: some View {
-        VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense + 2) {
-            HStack(spacing: MenuBarLayoutTokens.hDense) {
+        VStack(alignment: .leading, spacing: MenuBarLayoutTokens.space4) {
+            HStack(spacing: MenuBarLayoutTokens.space6) {
                 Text(tr("ui.tab.activity"))
-                    .font(.appSystem(size: 12, weight: .bold))
-                    .tracking(1.2)
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .bold))
                     .textCase(.uppercase)
                     .foregroundStyle(nativeTertiaryLabel)
 
@@ -73,10 +72,10 @@ extension MenuBarRoot {
 
             TextField(tr("ui.placeholder.filter_connection"), text: $networkFilterText)
                 .textFieldStyle(.roundedBorder)
-                .font(.appSystem(size: 12, weight: .regular))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .regular))
                 .foregroundStyle(nativePrimaryLabel)
 
-            HStack(spacing: MenuBarLayoutTokens.hDense) {
+            HStack(spacing: MenuBarLayoutTokens.space6) {
                 self.activityFilterMenu
                 self.activitySortMenu
 
@@ -95,7 +94,7 @@ extension MenuBarRoot {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+        .menuRowPadding(vertical: MenuBarLayoutTokens.space4)
     }
 
     var activityFilterMenu: some View {
@@ -189,11 +188,10 @@ extension MenuBarRoot {
         let source = self.appState.connections.prefix(120)
         let keyword = self.trimmedNetworkKeyword
 
-        let filtered: [ConnectionSummary]
-        if keyword.isEmpty && self.networkTransportFilter == .all {
-            filtered = Array(source)
+        let filtered: [ConnectionSummary] = if keyword.isEmpty, self.networkTransportFilter == .all {
+            Array(source)
         } else {
-            filtered = source.filter { conn in
+            source.filter { conn in
                 guard self.networkTransportFilter.matches(conn.metadata?.network) else { return false }
                 guard keyword.isEmpty || self.connectionSearchText(for: conn).localizedStandardContains(keyword) else {
                     return false
@@ -223,16 +221,16 @@ extension MenuBarRoot {
             ?? parsedRule?.payload.trimmedNonEmpty
             ?? "--"
 
-        return HStack(alignment: .center, spacing: MenuBarLayoutTokens.hDense) {
+        return HStack(alignment: .center, spacing: MenuBarLayoutTokens.space6) {
             Image(systemName: visual.symbol)
-                .font(.appSystem(size: 12, weight: .semibold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .semibold))
                 .foregroundStyle(visual.color)
                 .frame(
-                    width: MenuBarLayoutTokens.rowLeadingIconColumnWidth,
-                    height: MenuBarLayoutTokens.rowLeadingIconSize,
+                    width: MenuBarLayoutTokens.rowLeadingIcon,
+                    height: MenuBarLayoutTokens.rowLeadingIcon,
                     alignment: .center)
 
-            VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense) {
+            VStack(alignment: .leading, spacing: MenuBarLayoutTokens.space2) {
                 self.connectionRowTopLine(host: hostText, ruleType: ruleTypeText, rulePayload: rulePayloadText)
                 self.connectionRowMetrics(time: timeText, network: networkType, up: upText, down: downText)
                 self.activityChainsLine(parts: self.connectionChainsParts(conn.chains))
@@ -241,8 +239,8 @@ extension MenuBarRoot {
 
             self.connectionRowCloseButton(id: conn.id, hovered: hovered)
         }
-        .padding(.horizontal, MenuBarLayoutTokens.hRow)
-        .padding(.vertical, MenuBarLayoutTokens.vDense + 1)
+        .padding(.horizontal, MenuBarLayoutTokens.space4)
+        .padding(.vertical, MenuBarLayoutTokens.space2)
         .background(nativeHoverRowBackground(hovered))
         .onHover { hoveredConnectionID = self.nextHovered(
             current: hoveredConnectionID, target: conn.id, isHovering: $0) }
@@ -258,7 +256,7 @@ extension MenuBarRoot {
 
             HStack(spacing: ActivityLayout.topLineSpacing) {
                 Text(host)
-                    .font(.appSystem(size: 12, weight: .semibold))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .semibold))
                     .foregroundStyle(nativePrimaryLabel)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -293,14 +291,14 @@ extension MenuBarRoot {
                 self.activityMetricColumn(
                     symbol: "arrow.up",
                     text: up,
-                    symbolColor: nativeInfo.opacity(0.9),
+                    symbolColor: nativeInfo.opacity(MenuBarLayoutTokens.Opacity.solid),
                     spacing: 0,
                     truncation: .tail,
                     width: columnWidth)
                 self.activityMetricColumn(
                     symbol: "arrow.down",
                     text: down,
-                    symbolColor: nativePositive.opacity(0.9),
+                    symbolColor: nativePositive.opacity(MenuBarLayoutTokens.Opacity.solid),
                     spacing: 0,
                     truncation: .tail,
                     width: columnWidth)
@@ -314,7 +312,7 @@ extension MenuBarRoot {
             Task { await appState.closeConnection(id: id) }
         } label: {
             Image(systemName: "xmark")
-                .font(.appSystem(size: 8, weight: .semibold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                 .frame(width: 10, height: 10)
         }
         .buttonStyle(.plain)
@@ -353,7 +351,7 @@ extension MenuBarRoot {
         symbolColor: Color = .secondary,
         textColor: Color = .secondary,
         fallback: String? = nil,
-        spacing: CGFloat = 2,
+        spacing: CGFloat = MenuBarLayoutTokens.space2,
         truncation: Text.TruncationMode = .middle,
         width: CGFloat) -> some View
     {
@@ -361,11 +359,11 @@ extension MenuBarRoot {
 
         return HStack(spacing: spacing) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 9, weight: .semibold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                 .foregroundStyle(symbolColor)
                 .frame(width: 10, alignment: .leading)
             Text(renderedText)
-                .font(.appMonospaced(size: 10, weight: .regular))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .regular))
                 .foregroundStyle(textColor)
                 .lineLimit(1)
                 .truncationMode(truncation)
@@ -376,23 +374,23 @@ extension MenuBarRoot {
 
     func activityTopBadge(text: String) -> some View {
         Text(text)
-            .font(.appMonospaced(size: 9, weight: .semibold))
+            .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
             .foregroundStyle(nativeSecondaryLabel)
             .lineLimit(1)
             .truncationMode(.tail)
-            .minimumScaleFactor(0.85)
-            .padding(.horizontal, 2)
-            .padding(.vertical, 1)
+            .minimumScaleFactor(MenuBarLayoutTokens.minimumScale)
+            .padding(.horizontal, MenuBarLayoutTokens.space2)
+            .padding(.vertical, MenuBarLayoutTokens.space1)
             .background(nativeBadgeCapsule())
     }
 
     func activityTopPayload(text: String) -> some View {
         Text(text)
-            .font(.appMonospaced(size: 9, weight: .medium))
+            .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
             .foregroundStyle(nativeSecondaryLabel)
             .lineLimit(1)
             .truncationMode(.middle)
-            .minimumScaleFactor(0.85)
+            .minimumScaleFactor(MenuBarLayoutTokens.minimumScale)
             .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
@@ -400,14 +398,14 @@ extension MenuBarRoot {
         let chainText = parts.joined(separator: " > ")
         let displayText = parts.isEmpty ? tr("ui.common.na") : chainText
 
-        return HStack(spacing: 2) {
+        return HStack(spacing: MenuBarLayoutTokens.space2) {
             Image(systemName: "point.3.connected.trianglepath.dotted")
-                .font(.appSystem(size: 9, weight: .semibold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                 .foregroundStyle(nativeSecondaryLabel)
                 .frame(width: 10, alignment: .leading)
 
             Text(displayText)
-                .font(.appMonospaced(size: 10, weight: .regular))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .regular))
                 .foregroundStyle(nativeSecondaryLabel)
                 .lineLimit(1)
                 .truncationMode(.middle)
@@ -428,10 +426,12 @@ extension MenuBarRoot {
 
         var ruleWidth = max(
             ActivityLayout.topRuleMinWidth,
-            self.activityMonospacedTextWidth(ruleText, size: 9, weight: .semibold) + 4)
+            self
+                .activityMonospacedTextWidth(ruleText, size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold) +
+                4)
         var payloadWidth = max(
             ActivityLayout.topPayloadMinWidth,
-            self.activityMonospacedTextWidth(payloadText, size: 9, weight: .medium))
+            self.activityMonospacedTextWidth(payloadText, size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
         let desiredMetaWidth = ruleWidth + ActivityLayout.topMetaSpacing + payloadWidth
 
         if desiredMetaWidth > metaMaxWidth {
@@ -524,25 +524,25 @@ extension MenuBarRoot {
         let network = conn.metadata?.network?.lowercased() ?? ""
 
         if host.contains("google") || host.contains("gstatic") {
-            return ("shield.fill", nativePurple.opacity(0.92))
+            return ("shield.fill", nativePurple.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if host.contains("icloud") || host.contains("apple") {
-            return ("icloud.fill", nativeInfo.opacity(0.92))
+            return ("icloud.fill", nativeInfo.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if host.contains("github") {
-            return ("terminal.fill", nativeIndigo.opacity(0.9))
+            return ("terminal.fill", nativeIndigo.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if host.contains("twitter") || host.contains("x.com") {
-            return ("lock.fill", nativePositive.opacity(0.92))
+            return ("lock.fill", nativePositive.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if host.contains("amazon") {
-            return ("cart.fill", nativeWarning.opacity(0.92))
+            return ("cart.fill", nativeWarning.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if network.contains("udp") {
-            return ("dot.radiowaves.left.and.right", nativeTeal.opacity(0.92))
+            return ("dot.radiowaves.left.and.right", nativeTeal.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if network.contains("tcp") {
-            return ("network", nativeInfo.opacity(0.92))
+            return ("network", nativeInfo.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         return ("globe", nativeSecondaryLabel)
     }

--- a/Sources/ClashBar/Features/MenuBar/Tabs/LogsTabView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/LogsTabView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 extension MenuBarRoot {
     var logsTabBody: some View {
         let logs = self.visibleLogs
 
-        return VStack(alignment: .leading, spacing: MenuBarLayoutTokens.sectionGap) {
+        return VStack(alignment: .leading, spacing: T.space6) {
             self.logsControlCard(filteredCount: logs.count)
 
             if logs.isEmpty {
@@ -13,8 +15,8 @@ extension MenuBarRoot {
                 MeasurementAwareVStack(alignment: .leading, spacing: 0) {
                     SeparatedForEach(data: logs, id: \.id, separator: nativeSeparator) { log in
                         self.logEntryRow(log)
-                            .padding(.horizontal, MenuBarLayoutTokens.hRow)
-                            .padding(.vertical, MenuBarLayoutTokens.vDense + 2)
+                            .padding(.horizontal, T.space4)
+                            .padding(.vertical, T.space4)
                     }
                 }
             }
@@ -22,8 +24,8 @@ extension MenuBarRoot {
     }
 
     func logsControlCard(filteredCount: Int) -> some View {
-        VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense + 2) {
-            HStack(spacing: MenuBarLayoutTokens.hDense) {
+        VStack(alignment: .leading, spacing: T.space4) {
+            HStack(spacing: T.space6) {
                 self.logsSourceFilterButtons
 
                 Spacer(minLength: 0)
@@ -33,14 +35,14 @@ extension MenuBarRoot {
             self.logsSecondaryControlRow
             TextField(tr("ui.placeholder.search_logs"), text: $logSearchText)
                 .textFieldStyle(.roundedBorder)
-                .font(.appSystem(size: 12, weight: .regular))
+                .font(.app(size: T.FontSize.body, weight: .regular))
                 .foregroundStyle(nativePrimaryLabel)
         }
-        .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+        .menuRowPadding(vertical: T.space4)
     }
 
     var logsSecondaryControlRow: some View {
-        HStack(spacing: MenuBarLayoutTokens.hDense) {
+        HStack(spacing: T.space6) {
             self.logsLevelFilterButtons
 
             self.compactTopIcon(
@@ -104,19 +106,19 @@ extension MenuBarRoot {
     }
 
     // swiftlint:disable:next function_parameter_count
-    private func logFilterGroup<T: Hashable>(
+    private func logFilterGroup<V: Hashable>(
         symbol: String,
         allTitle: String,
         allSelected: Bool,
         selectAll: @escaping () -> Void,
-        items: [T],
-        itemTitle: @escaping (T) -> String,
-        itemSelected: @escaping (T) -> Bool,
-        toggleItem: @escaping (T) -> Void) -> some View
+        items: [V],
+        itemTitle: @escaping (V) -> String,
+        itemSelected: @escaping (V) -> Bool,
+        toggleItem: @escaping (V) -> Void) -> some View
     {
-        HStack(spacing: MenuBarLayoutTokens.hMicro + 1) {
+        HStack(spacing: T.space2) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 10, weight: .semibold))
+                .font(.app(size: T.FontSize.caption, weight: .semibold))
                 .foregroundStyle(nativeTertiaryLabel)
 
             self.logFilterToggleButton(title: allTitle, selected: allSelected, action: selectAll)
@@ -146,7 +148,7 @@ extension MenuBarRoot {
     private func logFilterButtonLabel(_ title: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(title)
-                .font(.appSystem(size: 11, weight: .medium))
+                .font(.app(size: T.FontSize.caption, weight: .medium))
                 .lineLimit(1)
         }
         .controlSize(.small)
@@ -235,55 +237,55 @@ extension MenuBarRoot {
         let tone = levelInfo.color
         let symbol = levelInfo.symbol
 
-        return HStack(alignment: .center, spacing: MenuBarLayoutTokens.hDense + 1) {
-            RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
-                .fill(tone.opacity(0.14))
+        return HStack(alignment: .center, spacing: T.space6) {
+            RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
+                .fill(tone.opacity(T.Opacity.tint))
                 .frame(
-                    width: MenuBarLayoutTokens.rowLeadingIconColumnWidth,
-                    height: MenuBarLayoutTokens.rowLeadingIconSize)
+                    width: T.rowLeadingIcon,
+                    height: T.rowLeadingIcon)
                 .overlay {
                     Image(systemName: symbol)
-                        .font(.appSystem(size: 9, weight: .semibold))
+                        .font(.app(size: T.FontSize.caption, weight: .semibold))
                         .foregroundStyle(tone)
                 }
 
-            VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense) {
-                HStack(spacing: MenuBarLayoutTokens.hMicro + 1) {
+            VStack(alignment: .leading, spacing: T.space2) {
+                HStack(spacing: T.space2) {
                     Text("[\(sourceInfo.label)]")
-                        .font(.appMonospaced(size: 10, weight: .semibold))
+                        .font(.app(size: T.FontSize.caption, weight: .semibold))
                         .foregroundStyle(sourceInfo.color)
 
                     Text("[\(levelInfo.label)]")
-                        .font(.appMonospaced(size: 10, weight: .semibold))
+                        .font(.app(size: T.FontSize.caption, weight: .semibold))
                         .foregroundStyle(tone)
 
                     if let protocolTag = parsed.protocolTag {
                         Text(protocolTag)
-                            .font(.appMonospaced(size: 10, weight: .semibold))
+                            .font(.app(size: T.FontSize.caption, weight: .semibold))
                             .foregroundStyle(parsed.protocolColor)
                     }
 
                     Text(ValueFormatter.dateTime(log.timestamp))
-                        .font(.appMonospaced(size: 10, weight: .regular))
+                        .font(.app(size: T.FontSize.caption, weight: .regular))
                         .foregroundStyle(nativeTertiaryLabel)
                         .lineLimit(1)
                 }
 
                 Text(parsed.mainText)
-                    .font(.appMonospaced(size: 11, weight: .regular))
+                    .font(.app(size: T.FontSize.caption, weight: .regular))
                     .foregroundStyle(nativePrimaryLabel)
                     .fixedSize(horizontal: false, vertical: true)
 
                 if let detailText = parsed.detailText {
                     Text(detailText)
-                        .font(.appMonospaced(size: 10, weight: .regular))
+                        .font(.app(size: T.FontSize.caption, weight: .regular))
                         .foregroundStyle(nativeSecondaryLabel)
                         .lineLimit(2)
-                        .padding(.leading, MenuBarLayoutTokens.hDense)
+                        .padding(.leading, T.space6)
                         .overlay(alignment: .leading) {
                             Rectangle()
-                                .fill(tone.opacity(0.30))
-                                .frame(width: MenuBarLayoutTokens.opticalNudge)
+                                .fill(tone.opacity(T.Opacity.tint))
+                                .frame(width: T.space1)
                         }
                 }
             }
@@ -320,7 +322,7 @@ extension MenuBarRoot {
         case .clashbar:
             (tr("ui.log_source.clashbar"), nativeSecondaryLabel)
         case .mihomo:
-            (tr("ui.log_source.mihomo"), nativeAccent.opacity(0.95))
+            (tr("ui.log_source.mihomo"), nativeAccent.opacity(T.Opacity.solid))
         }
     }
 
@@ -333,19 +335,19 @@ extension MenuBarRoot {
             return (
                 LogLevelFilter.error,
                 tr("ui.log_filter.error"),
-                nativeCritical.opacity(0.92),
+                nativeCritical.opacity(T.Opacity.solid),
                 "exclamationmark.octagon.fill")
         case .warning:
             return (
                 LogLevelFilter.warning,
                 tr("ui.log_filter.warning"),
-                nativeWarning.opacity(0.92),
+                nativeWarning.opacity(T.Opacity.solid),
                 "exclamationmark.triangle.fill")
         case .info:
             return (
                 LogLevelFilter.info,
                 tr("ui.log_filter.info"),
-                nativeAccent.opacity(0.9),
+                nativeAccent.opacity(T.Opacity.solid),
                 "info.circle.fill")
         }
     }
@@ -379,15 +381,15 @@ extension MenuBarRoot {
         }
 
         var protocolTag: String?
-        var protocolColor = nativeAccent.opacity(0.90)
+        var protocolColor = nativeAccent.opacity(T.Opacity.solid)
         if let tag = firstRegexCapture(in: message, regex: CachedLogRegex.protocolTag) {
             protocolTag = tag
             message = message.replacingOccurrences(of: tag, with: "").trimmed
 
             let upper = tag.uppercased()
-            if upper.contains("UDP") { protocolColor = nativeWarning.opacity(0.90) }
-            if upper.contains("DNS") { protocolColor = nativePositive.opacity(0.90) }
-            if upper.contains("HTTP") { protocolColor = nativeAccent.opacity(0.90) }
+            if upper.contains("UDP") { protocolColor = nativeWarning.opacity(T.Opacity.solid) }
+            if upper.contains("DNS") { protocolColor = nativePositive.opacity(T.Opacity.solid) }
+            if upper.contains("HTTP") { protocolColor = nativeAccent.opacity(T.Opacity.solid) }
         }
 
         if message.isEmpty {

--- a/Sources/ClashBar/Features/MenuBar/Tabs/ProxyProvidersAndGroupsView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/ProxyProvidersAndGroupsView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 extension MenuBarRoot {
     var proxyProvidersSection: some View {
         let providers = appState.sortedProxyProviderNames
 
-        return VStack(alignment: .leading, spacing: MenuBarLayoutTokens.sectionGap) {
+        return VStack(alignment: .leading, spacing: T.space6) {
             self.nodesSectionHeader(
                 tr("ui.section.proxy_providers"),
                 symbol: "shippingbox.fill",
@@ -32,7 +34,7 @@ extension MenuBarRoot {
         let remaining = ValueFormatter.subscriptionRemaining(total: total, upload: upload, download: download)
         let remainingRatio = ValueFormatter.subscriptionRemainingRatio(total: total, upload: upload, download: download)
         let quotaTextColumnWidth: CGFloat = 124
-        let rowHorizontalPadding = MenuBarLayoutTokens.hRow
+        let rowHorizontalPadding = T.space4
         let hovered = hoveredProxyProviderName == name
 
         return AttachedPopoverMenu(
@@ -40,37 +42,37 @@ extension MenuBarRoot {
                 Task { await appState.ensureProviderNodesLoaded(provider: name) }
             },
             label: {
-                VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense + 1) {
-                    HStack(spacing: MenuBarLayoutTokens.hDense) {
-                        RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
-                            .fill(nativeTeal.opacity(0.14))
+                VStack(alignment: .leading, spacing: T.space2) {
+                    HStack(spacing: T.space6) {
+                        RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
+                            .fill(nativeTeal.opacity(T.Opacity.tint))
                             .frame(
-                                width: MenuBarLayoutTokens.rowLeadingIconSize,
-                                height: MenuBarLayoutTokens.rowLeadingIconSize)
+                                width: T.rowLeadingIcon,
+                                height: T.rowLeadingIcon)
                             .overlay {
                                 Image(systemName: "shippingbox.fill")
-                                    .font(.appSystem(size: 9, weight: .semibold))
-                                    .foregroundStyle(nativeTeal.opacity(0.92))
+                                    .font(.app(size: T.FontSize.caption, weight: .semibold))
+                                    .foregroundStyle(nativeTeal.opacity(T.Opacity.solid))
                             }
 
                         Text(name)
-                            .font(.appSystem(size: 12, weight: .semibold))
+                            .font(.app(size: T.FontSize.body, weight: .semibold))
                             .foregroundStyle(nativePrimaryLabel)
                             .lineLimit(1)
 
                         if detail?.subscriptionInfo != nil {
                             Text(expireText)
-                                .font(.appSystem(size: 10, weight: .regular))
+                                .font(.app(size: T.FontSize.caption, weight: .regular))
                                 .foregroundStyle(nativeSecondaryLabel)
-                                .padding(.horizontal, MenuBarLayoutTokens.hMicro + 2)
-                                .padding(.vertical, MenuBarLayoutTokens.vDense)
+                                .padding(.horizontal, T.space2)
+                                .padding(.vertical, T.space2)
                                 .background(nativeBadgeCapsule())
                         }
 
                         Spacer(minLength: 0)
 
                         Text(updatedText)
-                            .font(.appSystem(size: 10, weight: .regular))
+                            .font(.app(size: T.FontSize.caption, weight: .regular))
                             .foregroundStyle(nativeTertiaryLabel)
 
                         self.providerActionButton(
@@ -88,45 +90,45 @@ extension MenuBarRoot {
                         }
 
                         Image(systemName: "chevron.right")
-                            .font(.appSystem(size: 10, weight: .semibold))
+                            .font(.app(size: T.FontSize.caption, weight: .semibold))
                             .foregroundStyle(nativeTertiaryLabel)
-                            .frame(width: 8, alignment: .trailing)
+                            .frame(width: T.space8, alignment: .trailing)
                     }
 
                     if let remaining, let total, let remainingRatio {
                         let quotaText =
                             "\(ValueFormatter.bytesCompactNoSpace(remaining)) / " +
                             "\(ValueFormatter.bytesCompactNoSpace(total))"
-                        HStack(spacing: MenuBarLayoutTokens.hDense) {
+                        HStack(spacing: T.space6) {
                             Text(quotaText)
-                                .font(.appMonospaced(size: 10, weight: .regular))
+                                .font(.app(size: T.FontSize.caption, weight: .regular))
                                 .foregroundStyle(nativeSecondaryLabel)
                                 .lineLimit(1)
                                 .frame(width: quotaTextColumnWidth, alignment: .leading)
 
                             GeometryReader { geo in
                                 ZStack(alignment: .leading) {
-                                    Capsule().fill(nativeControlFill.opacity(0.92))
+                                    Capsule().fill(nativeControlFill.opacity(T.Opacity.solid))
                                     Capsule()
-                                        .fill(nativeAccent.opacity(0.9))
+                                        .fill(nativeAccent.opacity(T.Opacity.solid))
                                         .frame(width: geo.size.width * remainingRatio)
                                 }
                             }
-                            .frame(height: 5)
+                            .frame(height: T.space4)
                         }
                     }
                 }
                 .padding(.horizontal, rowHorizontalPadding)
-                .padding(.vertical, MenuBarLayoutTokens.vDense + 1)
+                .padding(.vertical, T.space2)
                 .background(nativeHoverRowBackground(hovered))
                 .animation(.easeInOut(duration: 0.14), value: hovered)
             },
             content: { dismiss in
                 self.popoverHeader(name: name, count: nodeCount) {
                     Image(systemName: "shippingbox.fill")
-                        .font(.appSystem(size: 12, weight: .semibold))
-                        .foregroundStyle(nativeTeal.opacity(0.92))
-                        .frame(width: 16, alignment: .center)
+                        .font(.app(size: T.FontSize.body, weight: .semibold))
+                        .foregroundStyle(nativeTeal.opacity(T.Opacity.solid))
+                        .frame(width: T.rowLeadingIcon, alignment: .center)
                 }
 
                 let nodes = sortedProviderNodes(provider: name, detail: detail)
@@ -179,10 +181,10 @@ extension MenuBarRoot {
         return self.compactAsyncIconButton(
             symbol: kind.symbol,
             label: tr(kind.labelKey),
-            tint: tone.opacity(0.96),
+            tint: tone.opacity(T.Opacity.solid),
             isLoading: isLoading,
-            size: 16,
-            fontSize: 10.5,
+            size: T.rowLeadingIcon,
+            fontSize: T.FontSize.caption,
             hierarchicalSymbol: true,
             action: action)
     }
@@ -192,13 +194,13 @@ extension MenuBarRoot {
             ? appState.proxyGroups.filter { $0.hidden != true }
             : appState.proxyGroups
 
-        return VStack(alignment: .leading, spacing: MenuBarLayoutTokens.sectionGap) {
+        return VStack(alignment: .leading, spacing: T.space6) {
             self.nodesSectionHeader(
                 tr("ui.section.proxy_groups"),
                 symbol: "point.3.connected.trianglepath.dotted",
                 count: "\(groups.count)")
             {
-                HStack(spacing: MenuBarLayoutTokens.hDense) {
+                HStack(spacing: T.space6) {
                     self.compactTopIcon(
                         hideHiddenProxyGroups ? "eye.slash" : "eye",
                         label: tr(
@@ -229,7 +231,7 @@ extension MenuBarRoot {
             if groups.isEmpty {
                 emptyCard(tr("ui.empty.proxy_groups"))
             } else {
-                VStack(spacing: 2) {
+                VStack(spacing: T.space2) {
                     ForEach(groups, id: \.name) { group in
                         self.proxyGroupInlineRow(group)
                     }
@@ -251,8 +253,8 @@ extension MenuBarRoot {
         let nodeCount = group.all.count
         let iconURL = self.proxyGroupIconURL(group)
         let hasLeadingIcon = iconURL != nil
-        let rowHorizontalPadding = MenuBarLayoutTokens.hRow
-        let rowVerticalPadding: CGFloat = 1
+        let rowHorizontalPadding = T.space4
+        let rowVerticalPadding: CGFloat = T.space1
         let hovered = hoveredProxyGroupName == group.name
 
         return AttachedPopoverMenu {
@@ -260,35 +262,35 @@ extension MenuBarRoot {
                 let columns = self.proxyGroupMainColumnWidths(
                     totalWidth: geo.size.width,
                     hasLeadingIcon: hasLeadingIcon)
-                HStack(spacing: MenuBarLayoutTokens.hMicro) {
+                HStack(spacing: T.space1) {
                     if let iconURL {
                         self.proxyGroupLeadingIcon(iconURL)
                     }
 
                     Text(group.name)
-                        .font(.appSystem(size: 12, weight: .semibold))
+                        .font(.app(size: T.FontSize.body, weight: .semibold))
                         .foregroundStyle(nativePrimaryLabel)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                        .minimumScaleFactor(0.9)
+                        .minimumScaleFactor(T.minimumScale)
                         .frame(width: columns.name, alignment: .leading)
 
                     Text(currentNode)
-                        .font(.appSystem(size: 11, weight: .medium))
+                        .font(.app(size: T.FontSize.caption, weight: .medium))
                         .foregroundStyle(nativeSecondaryLabel)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                        .minimumScaleFactor(0.9)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
+                        .minimumScaleFactor(T.minimumScale)
+                        .padding(.horizontal, T.space4)
+                        .padding(.vertical, T.space1)
                         .background(nativeBadgeCapsule())
                         .frame(width: columns.current, alignment: .leading)
 
                     Text(delayText)
-                        .font(.appMonospaced(size: 10, weight: .regular))
+                        .font(.app(size: T.FontSize.caption, weight: .regular))
                         .foregroundStyle(latencyColor(delayValue))
                         .lineLimit(1)
-                        .minimumScaleFactor(0.85)
+                        .minimumScaleFactor(T.minimumScale)
                         .frame(width: columns.delay, alignment: .trailing)
 
                     self.providerActionButton(
@@ -300,13 +302,13 @@ extension MenuBarRoot {
                     .frame(width: 18, alignment: .center)
 
                     Image(systemName: "chevron.right")
-                        .font(.appSystem(size: 10, weight: .semibold))
+                        .font(.app(size: T.FontSize.caption, weight: .semibold))
                         .foregroundStyle(nativeTertiaryLabel)
-                        .frame(width: 8, alignment: .trailing)
+                        .frame(width: T.space8, alignment: .trailing)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             }
-            .frame(height: 20)
+            .frame(height: T.compactRowHeight)
             .padding(.horizontal, rowHorizontalPadding)
             .padding(.vertical, rowVerticalPadding)
             .background(nativeHoverRowBackground(hovered))
@@ -343,11 +345,11 @@ extension MenuBarRoot {
         totalWidth: CGFloat,
         hasLeadingIcon: Bool) -> (name: CGFloat, current: CGFloat, delay: CGFloat)
     {
-        let iconWidth: CGFloat = hasLeadingIcon ? MenuBarLayoutTokens.rowLeadingIconColumnWidth : 0
+        let iconWidth: CGFloat = hasLeadingIcon ? T.rowLeadingIcon : 0
         let actionWidth: CGFloat = 18
         let chevronWidth: CGFloat = 8
         let spacingCount: CGFloat = hasLeadingIcon ? 5 : 4
-        let spacing = MenuBarLayoutTokens.hMicro * spacingCount
+        let spacing = T.space1 * spacingCount
         let available = max(0, totalWidth - iconWidth - actionWidth - chevronWidth - spacing)
         let name = floor(available * 0.34)
         let delay = floor(available * 0.17)
@@ -364,13 +366,13 @@ extension MenuBarRoot {
                     .antialiased(true)
                     .aspectRatio(contentMode: .fit)
                     .frame(
-                        maxWidth: MenuBarLayoutTokens.rowLeadingIconSize,
-                        maxHeight: MenuBarLayoutTokens.rowLeadingIconSize)
+                        maxWidth: T.rowLeadingIcon,
+                        maxHeight: T.rowLeadingIcon)
             }
         }
         .frame(
-            width: MenuBarLayoutTokens.rowLeadingIconColumnWidth,
-            height: MenuBarLayoutTokens.rowLeadingIconSize,
+            width: T.rowLeadingIcon,
+            height: T.rowLeadingIcon,
             alignment: .center)
     }
 
@@ -385,26 +387,25 @@ extension MenuBarRoot {
         count: String? = nil,
         @ViewBuilder trailing: () -> some View = { EmptyView() }) -> some View
     {
-        HStack(spacing: MenuBarLayoutTokens.hDense) {
+        HStack(spacing: T.space6) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 10, weight: .semibold))
+                .font(.app(size: T.FontSize.caption, weight: .semibold))
                 .foregroundStyle(nativeTertiaryLabel)
                 .frame(
-                    width: MenuBarLayoutTokens.rowLeadingIconColumnWidth,
-                    height: MenuBarLayoutTokens.rowLeadingIconSize,
+                    width: T.rowLeadingIcon,
+                    height: T.rowLeadingIcon,
                     alignment: .center)
 
             Text(title)
-                .font(.appSystem(size: 12, weight: .bold))
-                .tracking(1.1)
+                .font(.app(size: T.FontSize.body, weight: .bold))
                 .foregroundStyle(nativeTertiaryLabel)
 
             if let count {
                 Text(count)
-                    .font(.appMonospaced(size: 10, weight: .bold))
+                    .font(.app(size: T.FontSize.caption, weight: .bold))
                     .foregroundStyle(nativeSecondaryLabel)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
+                    .padding(.horizontal, T.space4)
+                    .padding(.vertical, T.space1)
                     .background(nativeBadgeCapsule())
             }
 
@@ -412,10 +413,10 @@ extension MenuBarRoot {
             trailing()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, MenuBarLayoutTokens.hRow)
+        .padding(.horizontal, T.space4)
     }
 
-    func nextHovered<T: Equatable>(current: T?, target: T, isHovering: Bool) -> T? {
+    func nextHovered<V: Equatable>(current: V?, target: V, isHovering: Bool) -> V? {
         isHovering ? target : (current == target ? nil : current)
     }
 
@@ -425,29 +426,29 @@ extension MenuBarRoot {
         @ViewBuilder leading: () -> some View = { EmptyView() }) -> some View
     {
         VStack(spacing: 0) {
-            HStack(spacing: MenuBarLayoutTokens.hMicro) {
+            HStack(spacing: T.space1) {
                 leading()
 
                 Text(name)
-                    .font(.appSystem(size: 12, weight: .semibold))
+                    .font(.app(size: T.FontSize.body, weight: .semibold))
                     .foregroundStyle(nativePrimaryLabel)
                     .lineLimit(1)
 
                 Spacer(minLength: 0)
 
                 Text("\(count)")
-                    .font(.appMonospaced(size: 10, weight: .medium))
+                    .font(.app(size: T.FontSize.caption, weight: .medium))
                     .foregroundStyle(nativeSecondaryLabel)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 1)
+                    .padding(.horizontal, T.space4)
+                    .padding(.vertical, T.space1)
                     .background(nativeBadgeCapsule())
             }
-            .padding(.horizontal, 4)
-            .padding(.bottom, 2)
+            .padding(.horizontal, T.space4)
+            .padding(.bottom, T.space2)
 
             Divider()
                 .overlay(nativeSeparator)
-                .padding(.bottom, 1)
+                .padding(.bottom, T.space1)
         }
     }
 
@@ -458,11 +459,11 @@ extension MenuBarRoot {
     {
         if nodes.isEmpty {
             Text(tr("ui.common.na"))
-                .font(.appSystem(size: 11, weight: .regular))
+                .font(.app(size: T.FontSize.caption, weight: .regular))
                 .foregroundStyle(nativeSecondaryLabel)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 4)
+                .padding(.horizontal, T.space6)
+                .padding(.vertical, T.space4)
         } else {
             VStack(spacing: 0) {
                 ForEach(nodes, id: \.self) { node in
@@ -486,19 +487,19 @@ private struct ProxyGroupPopoverNodeItem: View {
 
     var body: some View {
         Button(action: self.action) {
-            HStack(spacing: MenuBarLayoutTokens.hMicro) {
+            HStack(spacing: T.space1) {
                 Image(systemName: self.selected ? "checkmark.circle.fill" : "circle")
-                    .font(.appSystem(size: 10, weight: .semibold))
+                    .font(.app(size: T.FontSize.caption, weight: .semibold))
                     .foregroundStyle(self
                         .selected ? Color(nsColor: .controlAccentColor) : Color(nsColor: .tertiaryLabelColor))
                     .frame(width: 11, alignment: .center)
 
                 Text(self.title)
-                    .font(.appSystem(size: 12, weight: self.selected ? .semibold : .medium))
+                    .font(.app(size: T.FontSize.body, weight: self.selected ? .semibold : .medium))
                     .foregroundStyle(self.selected ? Color.primary : Color.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .minimumScaleFactor(0.9)
+                    .minimumScaleFactor(T.minimumScale)
 
                 Spacer(minLength: 0)
 
@@ -511,11 +512,11 @@ private struct ProxyGroupPopoverNodeItem: View {
                 }
                 .frame(width: 56, alignment: .trailing)
             }
-            .frame(height: 20)
-            .padding(.horizontal, 4)
-            .padding(.vertical, 1)
+            .frame(height: T.compactRowHeight)
+            .padding(.horizontal, T.space4)
+            .padding(.vertical, T.space1)
             .background(
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
                     .fill(self.rowBackground))
         }
         .buttonStyle(.plain)
@@ -524,7 +525,7 @@ private struct ProxyGroupPopoverNodeItem: View {
 
     var rowBackground: Color {
         if self.selected {
-            return Color(nsColor: .controlAccentColor).opacity(0.18)
+            return Color(nsColor: .controlAccentColor).opacity(T.Opacity.tint)
         }
         if self.isHovered {
             return Color(nsColor: .selectedContentBackgroundColor).opacity(0.22)
@@ -542,20 +543,20 @@ private struct ProxyGroupPopoverNodeItem: View {
                 : self.delayColor.opacity(self.selected ? 1 : 0.94)
 
             Text(self.delayText)
-                .font(.appMonospaced(size: 10, weight: .semibold))
+                .font(.app(size: T.FontSize.caption, weight: .semibold))
                 .foregroundStyle(foreground)
                 .lineLimit(1)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 1.5)
+                .padding(.horizontal, T.space6)
+                .padding(.vertical, T.space1)
                 .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
                         .fill(background))
         } else {
             Text(self.delayText)
-                .font(.appMonospaced(size: 10, weight: .regular))
+                .font(.app(size: T.FontSize.caption, weight: .regular))
                 .foregroundStyle(self.delayColor.opacity(self.selected ? 1 : 0.85))
                 .lineLimit(1)
-                .minimumScaleFactor(0.85)
+                .minimumScaleFactor(T.minimumScale)
         }
     }
 }
@@ -566,7 +567,7 @@ private struct LatencyLoadingIndicator: View {
             .controlSize(.mini)
             .frame(width: 30, height: 14, alignment: .center)
             .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.24)))
+                RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
+                    .fill(Color(nsColor: .quaternaryLabelColor).opacity(T.Opacity.tint)))
     }
 }

--- a/Sources/ClashBar/Features/MenuBar/Tabs/ProxyTabView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/ProxyTabView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 extension MenuBarRoot {
     var quickRowTrailingColumnWidth: CGFloat {
         min(170, max(126, contentWidth * 0.44))
     }
 
     var proxyTabBody: some View {
-        VStack(alignment: .leading, spacing: MenuBarLayoutTokens.sectionGap) {
+        VStack(alignment: .leading, spacing: T.space6) {
             self.trafficOverview
             self.proxyQuickRows
             if !appState.sortedProxyProviderNames.isEmpty {
@@ -19,7 +21,7 @@ extension MenuBarRoot {
 
     var trafficOverview: some View {
         let sparklineHeight: CGFloat = 64
-        let sparklineHorizontalInset = MenuBarLayoutTokens.hRow
+        let sparklineHorizontalInset = T.space4
 
         return ZStack {
             TrafficSparklineView(
@@ -29,7 +31,7 @@ extension MenuBarRoot {
                 .padding(.horizontal, sparklineHorizontalInset)
 
             VStack(spacing: 0) {
-                HStack(spacing: MenuBarLayoutTokens.hDense) {
+                HStack(spacing: T.space6) {
                     self.cornerMetric(
                         symbol: "link",
                         value: "\(appState.connectionsCount)",
@@ -48,7 +50,7 @@ extension MenuBarRoot {
 
                 Spacer(minLength: 0)
 
-                HStack(spacing: MenuBarLayoutTokens.hDense) {
+                HStack(spacing: T.space6) {
                     self.cornerMetric(
                         symbol: "memorychip",
                         value: ValueFormatter.bytesInteger(appState.memory.inuse),
@@ -60,16 +62,16 @@ extension MenuBarRoot {
                         value: ValueFormatter.speedAndTotal(
                             rate: appState.traffic.down,
                             total: appState.displayDownTotal),
-                        color: nativePositive.opacity(0.92),
+                        color: nativePositive.opacity(T.Opacity.solid),
                         iconTrailing: true)
                         .frame(maxWidth: .infinity, alignment: .trailing)
                 }
             }
-            .padding(.horizontal, MenuBarLayoutTokens.hRow)
-            .padding(.vertical, MenuBarLayoutTokens.vDense)
+            .padding(.horizontal, T.space4)
+            .padding(.vertical, T.space2)
         }
         .frame(height: sparklineHeight)
-        .padding(.top, MenuBarLayoutTokens.vDense)
+        .padding(.top, T.space2)
     }
 
     func cornerMetric(
@@ -79,15 +81,15 @@ extension MenuBarRoot {
         iconTrailing: Bool = false) -> some View
     {
         let icon = Image(systemName: symbol)
-            .font(.appSystem(size: 11, weight: .semibold))
+            .font(.app(size: T.FontSize.caption, weight: .semibold))
             .foregroundStyle(color)
         let text = Text(value)
-            .font(.appMonospaced(size: 12, weight: .regular))
+            .font(.app(size: T.FontSize.body, weight: .regular))
             .foregroundStyle(nativeSecondaryLabel)
             .lineLimit(1)
-            .minimumScaleFactor(0.80)
+            .minimumScaleFactor(T.minimumScale)
 
-        return HStack(spacing: iconTrailing ? MenuBarLayoutTokens.hMicro : MenuBarLayoutTokens.hMicro + 1) {
+        return HStack(spacing: iconTrailing ? T.space1 : T.space2) {
             if iconTrailing { text; icon } else { icon; text }
         }
     }
@@ -99,16 +101,16 @@ extension MenuBarRoot {
                     title: tr("ui.quick.switch_config"),
                     symbol: "doc.text",
                     foreground: nativePurple,
-                    background: nativePurple.opacity(0.14))
+                    background: nativePurple.opacity(T.Opacity.tint))
                 {
-                    HStack(spacing: MenuBarLayoutTokens.hMicro + 1) {
+                    HStack(spacing: T.space2) {
                         Text(appState.selectedConfigName)
-                            .font(.appSystem(size: 11, weight: .regular))
+                            .font(.app(size: T.FontSize.caption, weight: .regular))
                             .lineLimit(1)
                             .truncationMode(.middle)
                             .foregroundStyle(nativeSecondaryLabel)
                         Image(systemName: "chevron.right")
-                            .font(.appSystem(size: 10, weight: .medium))
+                            .font(.app(size: T.FontSize.caption, weight: .medium))
                             .foregroundStyle(nativeTertiaryLabel)
                     }
                 }
@@ -150,7 +152,7 @@ extension MenuBarRoot {
                 title: tr("ui.quick.system_proxy"),
                 symbol: "network",
                 foreground: nativeInfo,
-                background: nativeInfo.opacity(0.14),
+                background: nativeInfo.opacity(T.Opacity.tint),
                 isDisabled: appState.isProxySyncing,
                 isOn: Binding(
                     get: { appState.isSystemProxyEnabled },
@@ -162,7 +164,7 @@ extension MenuBarRoot {
                 title: tr("ui.quick.tun_mode"),
                 symbol: "shield.lefthalf.filled",
                 foreground: nativePositive,
-                background: nativePositive.opacity(0.14),
+                background: nativePositive.opacity(T.Opacity.tint),
                 isDisabled: !appState.isTunToggleEnabled,
                 isOn: Binding(
                     get: { appState.isTunEnabled },
@@ -177,10 +179,10 @@ extension MenuBarRoot {
                     title: tr("ui.quick.copy_terminal"),
                     symbol: "terminal",
                     foreground: nativeWarning,
-                    background: nativeWarning.opacity(0.14))
+                    background: nativeWarning.opacity(T.Opacity.tint))
                 {
                     Image(systemName: "doc.on.doc")
-                        .font(.appSystem(size: 12, weight: .medium))
+                        .font(.app(size: T.FontSize.body, weight: .medium))
                         .foregroundStyle(hoveringCopyRow ? nativeSecondaryLabel : nativeTertiaryLabel.opacity(0.6))
                 }
             }
@@ -196,18 +198,18 @@ extension MenuBarRoot {
         background: Color,
         @ViewBuilder trailing: () -> some View) -> some View
     {
-        HStack(spacing: MenuBarLayoutTokens.hDense) {
+        HStack(spacing: T.space6) {
             self.quickIcon(symbol: symbol, foreground: foreground, background: background)
             Text(title)
-                .font(.appSystem(size: 12, weight: .medium))
+                .font(.app(size: T.FontSize.body, weight: .medium))
                 .foregroundStyle(nativePrimaryLabel)
             Spacer(minLength: 0)
             trailing()
                 .frame(width: self.quickRowTrailingColumnWidth, alignment: .trailing)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, MenuBarLayoutTokens.hRow)
-        .padding(.vertical, MenuBarLayoutTokens.vDense + 1)
+        .padding(.horizontal, T.space4)
+        .padding(.vertical, T.space2)
     }
 
     // swiftlint:disable:next function_parameter_count
@@ -234,14 +236,14 @@ extension MenuBarRoot {
     }
 
     func quickIcon(symbol: String, foreground: Color, background: Color) -> some View {
-        RoundedRectangle(cornerRadius: MenuBarLayoutTokens.iconCornerRadius, style: .continuous)
+        RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
             .fill(background)
             .frame(
-                width: MenuBarLayoutTokens.rowLeadingIconSize,
-                height: MenuBarLayoutTokens.rowLeadingIconSize)
+                width: T.rowLeadingIcon,
+                height: T.rowLeadingIcon)
             .overlay {
                 Image(systemName: symbol)
-                    .font(.appSystem(size: 12, weight: .semibold))
+                    .font(.app(size: T.FontSize.body, weight: .semibold))
                     .foregroundStyle(foreground)
             }
     }

--- a/Sources/ClashBar/Features/MenuBar/Tabs/RulesTabView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/RulesTabView.swift
@@ -7,7 +7,7 @@ extension MenuBarRoot {
 
         return VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 0) {
-                HStack(spacing: 8) {
+                HStack(spacing: MenuBarLayoutTokens.space8) {
                     self.rulesStatChip(title: tr("ui.rule.stats.rules"), value: "\(appState.rulesCount)")
                     self.rulesStatChip(title: tr("ui.rule.stats.sets"), value: "\(appState.providerRuleCount)")
                 }
@@ -15,45 +15,44 @@ extension MenuBarRoot {
                 Spacer(minLength: 0)
                 self.rulesRefreshButton
             }
-            .padding(.vertical, MenuBarLayoutTokens.vRow)
+            .padding(.vertical, MenuBarLayoutTokens.space6)
             .overlay(alignment: .bottom) {
                 Rectangle()
                     .fill(nativeSeparator)
-                    .frame(height: MenuBarLayoutTokens.hairline)
+                    .frame(height: MenuBarLayoutTokens.stroke)
             }
 
             HStack(spacing: 0) {
                 Color.clear.frame(width: 24)
                 Text(tr("ui.rules.column.target_type"))
-                    .font(.appSystem(size: 11, weight: .medium))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                     .foregroundStyle(nativeTertiaryLabel)
                     .frame(width: 120, alignment: .leading)
                 Text(tr("ui.rules.column.policy"))
-                    .font(.appSystem(size: 11, weight: .medium))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                     .foregroundStyle(nativeTertiaryLabel)
                     .frame(width: 90, alignment: .leading)
                 Text(tr("ui.rules.column.stats"))
-                    .font(.appSystem(size: 11, weight: .medium))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                     .foregroundStyle(nativeTertiaryLabel)
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .textCase(.uppercase)
-            .tracking(0.7)
-            .padding(.horizontal, MenuBarLayoutTokens.hRow)
-            .padding(.vertical, 6)
+            .padding(.horizontal, MenuBarLayoutTokens.space4)
+            .padding(.vertical, MenuBarLayoutTokens.space6)
             .background(nativeControlFill.opacity(0.35))
             .overlay(alignment: .bottom) {
                 Rectangle()
                     .fill(nativeSeparator)
-                    .frame(height: MenuBarLayoutTokens.hairline)
+                    .frame(height: MenuBarLayoutTokens.stroke)
             }
 
             if visibleRules.isEmpty {
                 Text(tr("ui.empty.rules"))
-                    .font(.appSystem(size: 12, weight: .regular))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .regular))
                     .foregroundStyle(nativeSecondaryLabel)
-                    .padding(.horizontal, MenuBarLayoutTokens.hRow)
-                    .padding(.vertical, MenuBarLayoutTokens.vDense + 6)
+                    .padding(.horizontal, MenuBarLayoutTokens.space4)
+                    .padding(.vertical, MenuBarLayoutTokens.space8)
                     .frame(maxWidth: .infinity, minHeight: 52, alignment: .topLeading)
             } else {
                 VStack(spacing: 0) {
@@ -63,7 +62,7 @@ extension MenuBarRoot {
                         if index < visibleRules.count - 1 {
                             Rectangle()
                                 .fill(nativeSeparator)
-                                .frame(height: MenuBarLayoutTokens.hairline)
+                                .frame(height: MenuBarLayoutTokens.stroke)
                         }
                     }
                 }
@@ -72,16 +71,16 @@ extension MenuBarRoot {
     }
 
     func rulesStatChip(title: String, value: String) -> some View {
-        HStack(spacing: 5) {
+        HStack(spacing: MenuBarLayoutTokens.space4) {
             Text(title.uppercased())
-                .font(.appSystem(size: 11, weight: .semibold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                 .foregroundStyle(nativeTertiaryLabel)
             Text(value)
-                .font(.appSystem(size: 12, weight: .bold))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .bold))
                 .foregroundStyle(nativePrimaryLabel)
         }
-        .padding(.horizontal, MenuBarLayoutTokens.hDense)
-        .padding(.vertical, MenuBarLayoutTokens.vDense)
+        .padding(.horizontal, MenuBarLayoutTokens.space6)
+        .padding(.vertical, MenuBarLayoutTokens.space2)
     }
 
     var rulesRefreshButton: some View {
@@ -108,58 +107,58 @@ extension MenuBarRoot {
 
         return HStack(spacing: 0) {
             Image(systemName: iconSpec.symbol)
-                .font(.appSystem(size: 14, weight: .medium))
+                .font(.app(size: MenuBarLayoutTokens.FontSize.subhead, weight: .medium))
                 .foregroundStyle(iconSpec.color)
                 .frame(width: 24, alignment: .leading)
 
-            VStack(alignment: .leading, spacing: 1.5) {
+            VStack(alignment: .leading, spacing: MenuBarLayoutTokens.space1) {
                 Text(targetText)
-                    .font(.appSystem(size: 13, weight: .medium))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .medium))
                     .foregroundStyle(nativePrimaryLabel)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Text(typeText)
-                    .font(.appSystem(size: 11, weight: .regular))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .regular))
                     .foregroundStyle(nativeTertiaryLabel)
                     .lineLimit(1)
             }
             .frame(width: 120, alignment: .leading)
-            .padding(.trailing, MenuBarLayoutTokens.hDense)
+            .padding(.trailing, MenuBarLayoutTokens.space6)
 
-            HStack(spacing: MenuBarLayoutTokens.hMicro) {
+            HStack(spacing: MenuBarLayoutTokens.space1) {
                 if let symbol = badge.symbol {
                     Image(systemName: symbol)
-                        .font(.appSystem(size: 10, weight: .semibold))
+                        .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .semibold))
                         .foregroundStyle(badge.color)
                 }
                 Text(policyText)
-                    .font(.appSystem(size: 11, weight: .medium))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .medium))
                     .foregroundStyle(badge.color)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
-            .padding(.horizontal, MenuBarLayoutTokens.hDense)
-            .padding(.vertical, MenuBarLayoutTokens.vDense)
+            .padding(.horizontal, MenuBarLayoutTokens.space6)
+            .padding(.vertical, MenuBarLayoutTokens.space2)
             .background(
                 Capsule(style: .continuous)
                     .fill(badge.background))
             .frame(width: 90, alignment: .leading)
 
-            VStack(alignment: .trailing, spacing: 1.5) {
+            VStack(alignment: .trailing, spacing: MenuBarLayoutTokens.space1) {
                 Text("\(stats.count)")
-                    .font(.appMonospaced(size: 12, weight: .regular))
+                    .font(.app(size: MenuBarLayoutTokens.FontSize.body, weight: .regular))
                     .foregroundStyle(stats.hasProvider ? nativeSecondaryLabel : nativeTertiaryLabel)
                 if let updatedText = stats.updatedText {
                     Text(updatedText)
-                        .font(.appSystem(size: 10, weight: .regular))
+                        .font(.app(size: MenuBarLayoutTokens.FontSize.caption, weight: .regular))
                         .foregroundStyle(nativeTertiaryLabel)
                         .lineLimit(1)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
         }
-        .padding(.horizontal, MenuBarLayoutTokens.hRow)
-        .frame(height: 32)
+        .padding(.horizontal, MenuBarLayoutTokens.space4)
+        .frame(height: MenuBarLayoutTokens.rowHeight)
         .background(nativeHoverRowBackground(hovered))
         .onHover { hoveredRuleIndex = self.nextHovered(
             current: hoveredRuleIndex, target: index, isHovering: $0) }
@@ -168,15 +167,15 @@ extension MenuBarRoot {
     func ruleTypeIcon(for type: String) -> (symbol: String, color: Color) {
         let lower = type.lowercased()
         if lower.contains("ipcidr") {
-            return ("globe.americas.fill", nativeInfo.opacity(0.9))
+            return ("globe.americas.fill", nativeInfo.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if lower.contains("domain") || lower.contains("suffix") || lower.contains("keyword") {
-            return ("network", nativeTeal.opacity(0.9))
+            return ("network", nativeTeal.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
         if lower.contains("ruleset") {
-            return ("archivebox.fill", nativeWarning.opacity(0.9))
+            return ("archivebox.fill", nativeWarning.opacity(MenuBarLayoutTokens.Opacity.solid))
         }
-        return ("circle.grid.2x2.fill", nativeIndigo.opacity(0.9))
+        return ("circle.grid.2x2.fill", nativeIndigo.opacity(MenuBarLayoutTokens.Opacity.solid))
     }
 
     func rulePolicyBadge(for policy: String) -> (symbol: String?, color: Color, background: Color) {
@@ -184,8 +183,8 @@ extension MenuBarRoot {
         if lower.contains("fishy") {
             return (
                 symbol: "exclamationmark.triangle.fill",
-                color: nativeAccent.opacity(0.92),
-                background: nativeAccent.opacity(0.16))
+                color: nativeAccent.opacity(MenuBarLayoutTokens.Opacity.solid),
+                background: nativeAccent.opacity(MenuBarLayoutTokens.Opacity.tint))
         }
         return (
             symbol: nil,

--- a/Sources/ClashBar/Features/MenuBar/Tabs/System/SystemTabView+Rows.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/System/SystemTabView+Rows.swift
@@ -1,29 +1,30 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 extension MenuBarRoot {
     func settingsCardHeader(_ title: String, symbol: String) -> some View {
-        HStack(spacing: MenuBarLayoutTokens.hDense) {
+        HStack(spacing: T.space6) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 10, weight: .semibold))
+                .font(.app(size: T.FontSize.caption, weight: .semibold))
                 .foregroundStyle(nativeTertiaryLabel)
             Text(title)
-                .font(.appSystem(size: 12, weight: .bold))
+                .font(.app(size: T.FontSize.body, weight: .bold))
                 .foregroundStyle(nativeTertiaryLabel)
-                .tracking(0.8)
                 .textCase(.uppercase)
             Spacer(minLength: 0)
         }
-        .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 1)
+        .menuRowPadding(vertical: T.space2)
     }
 
     func settingsRowLabel(symbol: String, title: String) -> some View {
-        HStack(spacing: MenuBarLayoutTokens.hDense) {
+        HStack(spacing: T.space6) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 11, weight: .semibold))
+                .font(.app(size: T.FontSize.caption, weight: .semibold))
                 .foregroundStyle(nativeTertiaryLabel)
                 .frame(width: 14, alignment: .center)
             Text(title)
-                .font(.appSystem(size: 12, weight: .medium))
+                .font(.app(size: T.FontSize.body, weight: .medium))
                 .foregroundStyle(nativePrimaryLabel)
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -31,7 +32,7 @@ extension MenuBarRoot {
     }
 
     func settingsToggleRow(_ title: String, symbol: String, isOn: Binding<Bool>) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: T.space8) {
             self.settingsRowLabel(symbol: symbol, title: title)
                 .layoutPriority(1)
             Spacer(minLength: 0)
@@ -40,7 +41,7 @@ extension MenuBarRoot {
                 .toggleStyle(.switch)
                 .controlSize(.small)
         }
-        .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+        .menuRowPadding(vertical: T.space4)
     }
 
     func settingsMenuRow(
@@ -53,21 +54,21 @@ extension MenuBarRoot {
     {
         let resolvedControlWidth = controlWidth ?? settingsMenuControlWidth
 
-        return HStack(spacing: 10) {
+        return HStack(spacing: T.space8) {
             self.settingsRowLabel(symbol: symbol, title: title)
                 .layoutPriority(1)
             Spacer(minLength: 0)
             AttachedPopoverMenu(width: popoverWidth ?? resolvedControlWidth) {
-                HStack(spacing: MenuBarLayoutTokens.hMicro + 1) {
+                HStack(spacing: T.space2) {
                     Text(valueText)
                         .foregroundStyle(nativeSecondaryLabel)
                         .lineLimit(1)
                         .truncationMode(.tail)
                     Image(systemName: "chevron.right")
-                        .font(.appSystem(size: 10, weight: .semibold))
+                        .font(.app(size: T.FontSize.caption, weight: .semibold))
                         .foregroundStyle(nativeTertiaryLabel)
                 }
-                .font(.appSystem(size: 11, weight: .medium))
+                .font(.app(size: T.FontSize.caption, weight: .medium))
                 .frame(maxWidth: .infinity, alignment: .trailing)
             } content: { dismiss in
                 options(dismiss)
@@ -76,7 +77,7 @@ extension MenuBarRoot {
             .buttonStyle(.bordered)
             .controlSize(.small)
         }
-        .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+        .menuRowPadding(vertical: T.space4)
     }
 
     // swiftlint:disable:next function_parameter_count
@@ -103,7 +104,7 @@ extension MenuBarRoot {
     }
 
     func settingsPortFieldRow(_ title: String, symbol: String, text: Binding<String>) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: T.space8) {
             self.settingsRowLabel(symbol: symbol, title: title)
                 .layoutPriority(1)
 
@@ -111,7 +112,7 @@ extension MenuBarRoot {
 
             TextField(tr("ui.placeholder.port"), text: text)
                 .textFieldStyle(.roundedBorder)
-                .font(.appMonospaced(size: 12, weight: .regular))
+                .font(.app(size: T.FontSize.body, weight: .regular))
                 .foregroundStyle(nativePrimaryLabel)
                 .multilineTextAlignment(.trailing)
                 .frame(width: settingsPortFieldWidth, alignment: .trailing)
@@ -144,22 +145,22 @@ extension MenuBarRoot {
     }
 
     func settingsFeedbackBanner(text: String, color: Color, symbol: String) -> some View {
-        HStack(spacing: MenuBarLayoutTokens.hDense) {
+        HStack(spacing: T.space6) {
             Image(systemName: symbol)
-                .font(.appSystem(size: 11, weight: .semibold))
+                .font(.app(size: T.FontSize.caption, weight: .semibold))
                 .foregroundStyle(color)
 
             Text(text)
-                .font(.appSystem(size: 11, weight: .medium))
+                .font(.app(size: T.FontSize.caption, weight: .medium))
                 .foregroundStyle(nativePrimaryLabel)
                 .lineLimit(2)
 
             Spacer(minLength: 0)
         }
-        .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+        .menuRowPadding(vertical: T.space4)
         .overlay {
-            RoundedRectangle(cornerRadius: MenuBarLayoutTokens.cardCornerRadius, style: .continuous)
-                .stroke(color.opacity(0.26), lineWidth: 0.7)
+            RoundedRectangle(cornerRadius: T.cornerRadius, style: .continuous)
+                .stroke(color.opacity(0.26), lineWidth: T.stroke)
         }
     }
 

--- a/Sources/ClashBar/Features/MenuBar/Tabs/System/SystemTabView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Tabs/System/SystemTabView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+private typealias T = MenuBarLayoutTokens
+
 extension MenuBarRoot {
     var settingsMenuControlWidth: CGFloat {
         min(152, max(118, contentWidth * 0.43))
@@ -19,15 +21,15 @@ extension MenuBarRoot {
 
     var settingsFeedbackState: (message: String, color: Color, symbol: String)? {
         if let error = appState.settingsErrorMessage.trimmedNonEmpty {
-            return (error, nativeCritical.opacity(0.92), "exclamationmark.triangle.fill")
+            return (error, nativeCritical.opacity(T.Opacity.solid), "exclamationmark.triangle.fill")
         }
 
         if let launchError = appState.launchAtLoginErrorMessage.trimmedNonEmpty {
-            return (launchError, nativeWarning.opacity(0.92), "exclamationmark.circle.fill")
+            return (launchError, nativeWarning.opacity(T.Opacity.solid), "exclamationmark.circle.fill")
         }
 
         if let saved = appState.settingsSavedMessage.trimmedNonEmpty {
-            return (saved, nativePositive.opacity(0.92), "checkmark.circle.fill")
+            return (saved, nativePositive.opacity(T.Opacity.solid), "checkmark.circle.fill")
         }
 
         return nil
@@ -93,7 +95,7 @@ extension MenuBarRoot {
         ]
         let selectedLogLevel = appState.stringValue(for: .logLevel)
 
-        return VStack(alignment: .leading, spacing: MenuBarLayoutTokens.sectionGap) {
+        return VStack(alignment: .leading, spacing: T.space6) {
             if let feedback = settingsFeedbackState {
                 settingsFeedbackBanner(
                     text: feedback.message,
@@ -149,20 +151,20 @@ extension MenuBarRoot {
                     tr("ui.section.proxy_ports"),
                     symbol: "point.3.connected.trianglepath.dotted")
 
-                VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense + 2) {
-                    HStack(spacing: MenuBarLayoutTokens.hDense) {
+                VStack(alignment: .leading, spacing: T.space4) {
+                    HStack(spacing: T.space6) {
                         Text(tr("ui.settings.ports_auto_save_hint"))
-                            .font(.appSystem(size: 11, weight: .regular))
+                            .font(.app(size: T.FontSize.caption, weight: .regular))
                             .foregroundStyle(nativeSecondaryLabel)
 
                         Spacer(minLength: 0)
 
                         if self.portAutoSaving {
-                            HStack(spacing: MenuBarLayoutTokens.hMicro + 1) {
+                            HStack(spacing: T.space2) {
                                 ProgressView()
                                     .controlSize(.mini)
                                 Text(tr("ui.settings.ports_auto_saving"))
-                                    .font(.appSystem(size: 10, weight: .medium))
+                                    .font(.app(size: T.FontSize.caption, weight: .medium))
                                     .foregroundStyle(nativeSecondaryLabel)
                             }
                         }
@@ -175,7 +177,7 @@ extension MenuBarRoot {
                             text: item.text)
                     }
                 }
-                .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+                .menuRowPadding(vertical: T.space4)
             }
 
             VStack(spacing: 0) {
@@ -183,8 +185,8 @@ extension MenuBarRoot {
                     tr("ui.section.maintenance"),
                     symbol: "wrench.and.screwdriver")
 
-                VStack(alignment: .leading, spacing: MenuBarLayoutTokens.vDense + 2) {
-                    HStack(spacing: MenuBarLayoutTokens.hDense) {
+                VStack(alignment: .leading, spacing: T.space4) {
+                    HStack(spacing: T.space6) {
                         ForEach(maintenanceActions, id: \.titleKey) { item in
                             maintenanceActionButton(tr(item.titleKey), symbol: item.symbol) {
                                 await item.action()
@@ -192,7 +194,7 @@ extension MenuBarRoot {
                         }
                     }
 
-                    HStack(spacing: MenuBarLayoutTokens.hDense) {
+                    HStack(spacing: T.space6) {
                         Button {
                             appState.showCoreDirectoryInFinder()
                         } label: {
@@ -203,7 +205,7 @@ extension MenuBarRoot {
                         .controlSize(.small)
                     }
                 }
-                .menuRowPadding(vertical: MenuBarLayoutTokens.vDense + 2)
+                .menuRowPadding(vertical: T.space4)
             }
         }
     }

--- a/Sources/ClashBar/UI/Shared/AppFonts.swift
+++ b/Sources/ClashBar/UI/Shared/AppFonts.swift
@@ -1,14 +1,17 @@
 import AppKit
 import SwiftUI
 
-extension Font {
-    static func appSystem(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        Font(NSFont.systemFont(ofSize: size, weight: weight.nsFontWeight))
-    }
+private typealias FS = MenuBarLayoutTokens.FontSize
 
-    static func appMonospaced(size: CGFloat, weight: Font.Weight = .regular) -> Font {
+extension Font {
+    static func app(size: CGFloat, weight: Font.Weight = .regular) -> Font {
         Font(NSFont.monospacedSystemFont(ofSize: size, weight: weight.nsFontWeight))
     }
+
+    static let appCaption = app(size: FS.caption, weight: .medium)
+    static let appBody = app(size: FS.body, weight: .medium)
+    static let appSubhead = app(size: FS.subhead, weight: .semibold)
+    static let appTitle = app(size: FS.title, weight: .bold)
 }
 
 extension Font.Weight {


### PR DESCRIPTION
This pull request refactors the menu bar UI components to consistently use the `MenuBarLayoutTokens` struct for layout, spacing, font, color, and opacity values. The goal is to centralize style definitions, improve maintainability, and ensure visual consistency across the app. The changes touch multiple files and UI elements, replacing hardcoded values and scattered constants with standardized tokens.

**UI Style Token Standardization**

* Replaced hardcoded spacing, padding, font sizes, corner radii, stroke widths, and shadow parameters in `AttachedPopoverMenu`, `AttachedPopoverMenuItem`, and `AttachedPopoverMenuDivider` with values from `MenuBarLayoutTokens`, improving consistency and maintainability. [[1]](diffhunk://#diff-a97656a475c58afa854db114c126dee49bb0bb4c506df728d1878214fc6bd3c5L80-R88) [[2]](diffhunk://#diff-a97656a475c58afa854db114c126dee49bb0bb4c506df728d1878214fc6bd3c5L121-R136) [[3]](diffhunk://#diff-a97656a475c58afa854db114c126dee49bb0bb4c506df728d1878214fc6bd3c5L159-R159)
* Updated `StatusItemContentView` and `StatusItemController` to use `MenuBarLayoutTokens.space1` and `MenuBarLayoutTokens.space8` for horizontal padding, replacing previous optical nudge and page constants. [[1]](diffhunk://#diff-819d18c052c7bd5656ca4b13ddc1968ef418d613553230dd63d4c91fb34e866fL10-R10) [[2]](diffhunk://#diff-70c5292dae8c3e5bd1625217225e266e476cb81d8320f5f50f3226b49c10cc5eL42-R42)

**MenuBarCommonViews Enhancements**

* Centralized style values in `MenuBarCommonViews.swift`: spacing, font, color opacity, scale factors, background, and shadow now reference `MenuBarLayoutTokens`, including theme-specific color opacities and minimum scale factors. [[1]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L34-L42) [[2]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L150-R174) [[3]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L221-R227) [[4]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L243-R255) [[5]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L282-R310) [[6]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L380-R382) [[7]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L410-R410) [[8]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L447-R447)

**Codebase Simplification**

* Introduced `private typealias T = MenuBarLayoutTokens` in relevant files for concise token usage. [[1]](diffhunk://#diff-a97656a475c58afa854db114c126dee49bb0bb4c506df728d1878214fc6bd3c5L4-R6) [[2]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22R3-R4) [[3]](diffhunk://#diff-f295990c3d4b83d446e8d6f077d0b06a992b2d046f461ef94d5b9cb29c802b18R3-R4)
* Removed redundant `panelMeasurementMode` environment checks, simplifying component logic and focusing the layout on token-driven values. [[1]](diffhunk://#diff-a97656a475c58afa854db114c126dee49bb0bb4c506df728d1878214fc6bd3c5L32-L34) [[2]](diffhunk://#diff-a97656a475c58afa854db114c126dee49bb0bb4c506df728d1878214fc6bd3c5L59) [[3]](diffhunk://#diff-94ce2fec2a12ddc5c3d5104e6f6bb170dfe83b30d96008b5bb733f6f657b0a22L54-R70)

These changes collectively make the UI easier to update and ensure a uniform appearance throughout the app.