### PR TITLE
fix(status-bar): enable template mode for status item icon

### DIFF
--- a/Sources/ClashBar/App/StatusItem/StatusItemContentView.swift
+++ b/Sources/ClashBar/App/StatusItem/StatusItemContentView.swift
@@ -237,7 +237,7 @@ final class StatusItemContentView: NSView {
             }
 
             guard rendered.representations.isEmpty == false else { continue }
-            rendered.isTemplate = false
+            rendered.isTemplate = true
             images[theme] = rendered
         }
 


### PR DESCRIPTION
## Summary
- Set `isTemplate = true` for status bar icon to match macOS system behavior
- This allows the icon to automatically dim when the app loses focus
- Consistent with other system status bar items like battery and WiFi icons

## Problem
Status bar icon does not dim on dual-screen focus loss, while other system icons (battery, WiFi) properly dim when the app loses focus.

## Solution
Changed `isTemplate` property from `false` to `true` in `StatusItemContentView.swift:240`. This enables macOS to automatically manage the icon's appearance based on app focus state.

## Test Plan
- [x] Built and tested on macOS 15.4.1 with dual monitor setup
- [x] Verified icon dims correctly when app loses focus
- [x] Verified icon appearance remains correct in both light and dark modes