### PR TITLE
feat(config): 配置菜单显示变更/检查状态并支持单项订阅刷新

### DIFF
--- a/Sources/ClashBar/App/Session/AppSession.swift
+++ b/Sources/ClashBar/App/Session/AppSession.swift
@@ -47,6 +47,9 @@ final class AppSession: ObservableObject {
     @Published var selectedConfigName: String = "-"
     @Published var configDirectoryPath: String = "-"
     @Published var availableConfigFileNames: [String] = []
+    @Published var configMenuStatusSubtitleByName: [String: String] = [:]
+    @Published var remoteConfigUpdateInFlightNames: Set<String> = []
+    @Published var remoteConfigUpdateFeedbackByName: [String: Bool] = [:]
 
     @Published var proxyGroups: [ProxyGroup] = []
     @Published var groupLatencyLoading: Set<String> = []
@@ -349,6 +352,7 @@ final class AppSession: ObservableObject {
     let selectedConfigKey = "clashbar.config.selected.filename"
     let legacySelectedConfigKey = "clashbar.config.selected"
     let remoteConfigSourcesKey = "clashbar.config.remote.sources.v1"
+    let remoteConfigLastCheckSucceededAtKey = "clashbar.config.remote.last_check_succeeded_at.v1"
     let lastSuccessfulConfigPathKey = "clashbar.last.success.config.path"
     let editableSettingsSnapshotKey = "clashbar.settings.editable.snapshot.v1"
     let systemProxyEnabledOnQuitKey = "clashbar.system_proxy.enabled_on_quit"
@@ -390,6 +394,8 @@ final class AppSession: ObservableObject {
     var pendingCoreFeatureRecoveryState: CoreFeatureRecoveryState?
     var deferredEditableSettingsOverlay: (snapshot: EditableSettingsSnapshot, syncingKey: String)?
     var remoteConfigSources: [String: String] = [:]
+    var remoteConfigLastCheckSucceededAt: [String: TimeInterval] = [:]
+    var remoteConfigUpdateFeedbackClearTasks: [String: Task<Void, Never>] = [:]
     var externalControllerWarningKeys: Set<String> = []
     let streamJSONDecoder = JSONDecoder()
     let initialNoCoreSetupGuideShownKey = "clashbar.core.install.guide.shown.v1"
@@ -483,7 +489,9 @@ final class AppSession: ObservableObject {
         restoreSavedConfigDirectory()
         restoreLastSuccessfulConfigIfAvailable()
         self.remoteConfigSources = loadPersistedRemoteConfigSources()
+        self.remoteConfigLastCheckSucceededAt = loadPersistedRemoteConfigLastCheckSucceededAt()
         pruneRemoteConfigSourcesIfNeeded()
+        pruneRemoteConfigLastCheckSucceededAtIfNeeded()
         // Always start in local mode. Remote target is session-level only.
         self.remoteMachineStore.resetActiveTarget()
         self.controllerUIURL = makeControllerUIURL(self.controller)
@@ -539,6 +547,10 @@ final class AppSession: ObservableObject {
             webSocketTask.cancel(with: .goingAway, reason: nil)
         }
         providerRefreshTask?.cancel()
+        for task in remoteConfigUpdateFeedbackClearTasks.values {
+            task.cancel()
+        }
+        remoteConfigUpdateFeedbackClearTasks.removeAll()
     }
 
     private static func resolveBundledMihomoCoreFlag() -> Bool {

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+Config.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+Config.swift
@@ -4,8 +4,47 @@ import UniformTypeIdentifiers
 
 @MainActor
 extension AppSession {
+    private enum RemoteConfigWriteResult {
+        case changed
+        case unchanged
+    }
+
     private func reloadRuntimeConfigUseCase() throws -> ReloadRuntimeConfigUseCase {
         try ReloadRuntimeConfigUseCase(repository: DefaultRuntimeConfigRepository(transport: self.clientOrThrow()))
+    }
+
+    func isRemoteConfigFile(named fileName: String) -> Bool {
+        self.remoteConfigSources[fileName] != nil
+    }
+
+    func configMenuStatusSubtitle(for fileName: String) -> String? {
+        self.configMenuStatusSubtitleByName[fileName]
+    }
+
+    func refreshConfigMenuStatusSnapshot() {
+        let now = Date()
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        formatter.locale = Locale(identifier: self.uiLanguage.localeIdentifier)
+
+        var snapshot: [String: String] = [:]
+        let keys: Set<URLResourceKey> = [.contentModificationDateKey]
+        for configURL in self.configRepository.availableConfigs {
+            let fileName = configURL.lastPathComponent
+            let modifiedDate = (try? configURL.resourceValues(forKeys: keys))?.contentModificationDate
+            let modifiedText = self.menuRelativeTimeText(from: modifiedDate, now: now, formatter: formatter)
+
+            let checkedText: String
+            if let checkedTimestamp = self.remoteConfigLastCheckSucceededAt[fileName], checkedTimestamp > 0 {
+                let checkedDate = Date(timeIntervalSince1970: checkedTimestamp)
+                checkedText = self.menuRelativeTimeText(from: checkedDate, now: now, formatter: formatter)
+            } else {
+                checkedText = self.tr("ui.quick.config_status.never_checked")
+            }
+
+            snapshot[fileName] = self.tr("ui.quick.config_status.subtitle", modifiedText, checkedText)
+        }
+        self.configMenuStatusSubtitleByName = snapshot
     }
 
     func seedBundledConfigIfNeeded() {
@@ -194,6 +233,7 @@ extension AppSession {
             try writeConfigData(data, to: targetURL)
 
             self.updateRemoteConfigSource(for: fileName, urlString: remoteURL.absoluteString)
+            self.markRemoteConfigCheckSucceeded(fileNames: Set([fileName]))
             let message = tr("log.config.import_remote.success", fileName)
             appendLog(level: "info", message: message)
 
@@ -220,29 +260,24 @@ extension AppSession {
         }
 
         let userAgent = await remoteSubscriptionUserAgent()
-        var updatedFileNames: Set<String> = []
+        var changedFileNames: Set<String> = []
+        var succeededFileNames: Set<String> = []
         var failedCount = 0
 
         for fileName in sources.keys.sorted() {
-            guard let urlString = sources[fileName],
-                  let remoteURL = URL(string: urlString),
-                  isSupportedRemoteConfigURL(remoteURL)
-            else {
-                failedCount += 1
-                appendLog(
-                    level: "error",
-                    message: tr(
-                        "log.config.remote.update_item_failed",
-                        fileName,
-                        tr("log.config.remote.invalid_url", sources[fileName] ?? fileName)))
-                continue
-            }
-
-            let targetURL = configDirectory.appendingPathComponent(fileName, isDirectory: false)
             do {
-                let data = try await downloadRemoteConfigData(from: remoteURL, userAgent: userAgent)
-                try writeConfigData(data, to: targetURL)
-                updatedFileNames.insert(fileName)
+                if let result = try await self.updateSingleRemoteConfigFile(
+                    named: fileName,
+                    configDirectory: configDirectory,
+                    userAgent: userAgent)
+                {
+                    succeededFileNames.insert(fileName)
+                    if case .changed = result {
+                        changedFileNames.insert(fileName)
+                    }
+                } else {
+                    failedCount += 1
+                }
             } catch {
                 failedCount += 1
                 appendLog(
@@ -251,11 +286,114 @@ extension AppSession {
             }
         }
 
+        if !succeededFileNames.isEmpty {
+            self.markRemoteConfigCheckSucceeded(fileNames: succeededFileNames)
+        }
         self.refreshConfigStateAfterMutation()
-        appendLog(level: "info", message: tr("log.config.remote.update_summary", updatedFileNames.count, failedCount))
+        appendLog(level: "info", message: tr("log.config.remote.update_summary", changedFileNames.count, failedCount))
 
-        if self.shouldAutoReloadCurrentConfig(updatedFileNames: updatedFileNames) {
+        if self.shouldAutoReloadCurrentConfig(updatedFileNames: changedFileNames) {
             await self.reloadConfig()
+        }
+    }
+
+    func updateRemoteConfigFile(named fileName: String) async {
+        guard let configDirectory = ensureConfigDirectoryAvailable() else { return }
+        pruneRemoteConfigSourcesIfNeeded()
+
+        guard remoteConfigSources[fileName] != nil else {
+            appendLog(
+                level: "error",
+                message: tr("log.config.remote.update_item_failed", fileName, tr("log.config.remote.no_sources")))
+            return
+        }
+        guard !self.remoteConfigUpdateInFlightNames.contains(fileName) else { return }
+
+        self.remoteConfigUpdateInFlightNames.insert(fileName)
+        self.remoteConfigUpdateFeedbackByName.removeValue(forKey: fileName)
+        defer { self.remoteConfigUpdateInFlightNames.remove(fileName) }
+
+        do {
+            let userAgent = await remoteSubscriptionUserAgent()
+            if let result = try await self.updateSingleRemoteConfigFile(
+                named: fileName,
+                configDirectory: configDirectory,
+                userAgent: userAgent)
+            {
+                self.markRemoteConfigCheckSucceeded(fileNames: Set([fileName]))
+                self.refreshConfigStateAfterMutation()
+                if case .changed = result,
+                   self.shouldAutoReloadCurrentConfig(updatedFileNames: [fileName])
+                {
+                    await self.reloadConfig()
+                }
+                self.markRemoteConfigUpdateFeedback(for: fileName, success: true)
+            }
+        } catch {
+            appendLog(
+                level: "error",
+                message: tr("log.config.remote.update_item_failed", fileName, error.localizedDescription))
+            self.markRemoteConfigUpdateFeedback(for: fileName, success: false)
+        }
+    }
+
+    private func updateSingleRemoteConfigFile(
+        named fileName: String,
+        configDirectory: URL,
+        userAgent: String) async throws -> RemoteConfigWriteResult?
+    {
+        guard let urlString = remoteConfigSources[fileName],
+              let remoteURL = URL(string: urlString),
+              isSupportedRemoteConfigURL(remoteURL)
+        else {
+            appendLog(
+                level: "error",
+                message: tr(
+                    "log.config.remote.update_item_failed",
+                    fileName,
+                    tr("log.config.remote.invalid_url", remoteConfigSources[fileName] ?? fileName)))
+            return nil
+        }
+
+        let targetURL = configDirectory.appendingPathComponent(fileName, isDirectory: false)
+        let data = try await downloadRemoteConfigData(from: remoteURL, userAgent: userAgent)
+        if let existing = try? Data(contentsOf: targetURL), existing == data {
+            return .unchanged
+        }
+        try self.writeConfigData(data, to: targetURL)
+        return .changed
+    }
+
+    private func markRemoteConfigCheckSucceeded(fileNames: Set<String>, at now: Date = Date()) {
+        guard !fileNames.isEmpty else { return }
+        let timestamp = now.timeIntervalSince1970
+        for fileName in fileNames where self.remoteConfigSources[fileName] != nil {
+            self.remoteConfigLastCheckSucceededAt[fileName] = timestamp
+        }
+        self.persistRemoteConfigLastCheckSucceededAt()
+        self.refreshConfigMenuStatusSnapshot()
+    }
+
+    private func menuRelativeTimeText(
+        from date: Date?,
+        now: Date,
+        formatter: RelativeDateTimeFormatter) -> String
+    {
+        guard let date else { return self.tr("ui.common.unknown") }
+        let safeDate = min(date, now)
+        if now.timeIntervalSince(safeDate) < 45 {
+            return self.tr("ui.quick.config_status.just_now")
+        }
+        return formatter.localizedString(for: safeDate, relativeTo: now)
+    }
+
+    private func markRemoteConfigUpdateFeedback(for fileName: String, success: Bool) {
+        self.remoteConfigUpdateFeedbackClearTasks[fileName]?.cancel()
+        self.remoteConfigUpdateFeedbackByName[fileName] = success
+        self.remoteConfigUpdateFeedbackClearTasks[fileName] = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            self.remoteConfigUpdateFeedbackByName.removeValue(forKey: fileName)
+            self.remoteConfigUpdateFeedbackClearTasks.removeValue(forKey: fileName)
         }
     }
 

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+Persistence.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+Persistence.swift
@@ -70,6 +70,10 @@ extension AppSession {
             selectedConfigName = first
         }
         self.pruneRemoteConfigSourcesIfNeeded()
+        self.pruneRemoteConfigLastCheckSucceededAtIfNeeded()
+        self.configMenuStatusSubtitleByName = self.configMenuStatusSubtitleByName.filter { availableConfigFileNames
+            .contains($0.key)
+        }
     }
 
     func ensureAPIClient() {
@@ -131,11 +135,41 @@ extension AppSession {
         defaults.set(remoteConfigSources, forKey: remoteConfigSourcesKey)
     }
 
+    func loadPersistedRemoteConfigLastCheckSucceededAt() -> [String: TimeInterval] {
+        guard let stored = defaults.dictionary(forKey: remoteConfigLastCheckSucceededAtKey)
+            as? [String: TimeInterval]
+        else {
+            return [:]
+        }
+
+        var result: [String: TimeInterval] = [:]
+        for (fileName, timestamp) in stored where timestamp > 0 {
+            guard let normalizedName = normalizedConfigFileName(fileName), normalizedName == fileName else { continue }
+            result[normalizedName] = timestamp
+        }
+        return result
+    }
+
+    func persistRemoteConfigLastCheckSucceededAt() {
+        defaults.set(remoteConfigLastCheckSucceededAt, forKey: remoteConfigLastCheckSucceededAtKey)
+    }
+
     func pruneRemoteConfigSourcesIfNeeded() {
         let availableNames = Set(availableConfigFileNames)
         let filtered = remoteConfigSources.filter { availableNames.contains($0.key) }
         guard filtered != remoteConfigSources else { return }
         remoteConfigSources = filtered
         self.persistRemoteConfigSources()
+    }
+
+    func pruneRemoteConfigLastCheckSucceededAtIfNeeded() {
+        let availableNames = Set(availableConfigFileNames)
+        let remoteNames = Set(remoteConfigSources.keys)
+        let filtered = remoteConfigLastCheckSucceededAt.filter {
+            availableNames.contains($0.key) && remoteNames.contains($0.key)
+        }
+        guard filtered != remoteConfigLastCheckSucceededAt else { return }
+        remoteConfigLastCheckSucceededAt = filtered
+        self.persistRemoteConfigLastCheckSucceededAt()
     }
 }

--- a/Sources/ClashBar/Features/MenuBar/Proxy/Views/ProxyTabView.swift
+++ b/Sources/ClashBar/Features/MenuBar/Proxy/Views/ProxyTabView.swift
@@ -36,12 +36,40 @@ extension MenuBarRootView {
     @ViewBuilder
     func configMenuContent(dismiss: @escaping () -> Void) -> some View {
         ForEach(appSession.availableConfigFileNames, id: \.self) { name in
-            AttachedPopoverMenuItem(
-                title: name,
-                selected: name == appSession.selectedConfigName)
-            {
-                dismiss()
-                Task { await appSession.selectConfigFile(named: name) }
+            HStack(spacing: T.space4) {
+                AttachedPopoverMenuItem(
+                    title: name,
+                    subtitle: appSession.configMenuStatusSubtitle(for: name),
+                    selected: name == appSession.selectedConfigName)
+                {
+                    dismiss()
+                    Task { await appSession.selectConfigFile(named: name) }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                if appSession.isRemoteConfigFile(named: name) {
+                    Button {
+                        Task { await appSession.updateRemoteConfigFile(named: name) }
+                    } label: {
+                        Group {
+                            if appSession.remoteConfigUpdateInFlightNames.contains(name) {
+                                ProgressView()
+                                    .controlSize(.mini)
+                            } else if let success = appSession.remoteConfigUpdateFeedbackByName[name] {
+                                Image(systemName: success ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .font(.app(size: T.FontSize.caption, weight: .semibold))
+                                    .foregroundStyle(success ? nativePositive : nativeWarning)
+                            } else {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.app(size: T.FontSize.caption, weight: .semibold))
+                                    .foregroundStyle(nativeTertiaryLabel)
+                            }
+                        }
+                        .padding(T.space2)
+                    }
+                    .buttonStyle(.plain)
+                    .help(tr("ui.action.refresh"))
+                }
             }
         }
         AttachedPopoverMenuDivider()
@@ -172,7 +200,9 @@ extension MenuBarRootView {
                         .foregroundStyle(nativeTertiaryLabel)
                 }
             } else {
-                AttachedPopoverMenu { _ in
+                AttachedPopoverMenu(onWillPresent: {
+                    self.appSession.refreshConfigMenuStatusSnapshot()
+                }) { _ in
                     self.quickRowContent(
                         title: tr("ui.quick.switch_config"),
                         symbol: "doc.text",

--- a/Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings
@@ -84,6 +84,9 @@
 "ui.quick.import_remote_config" = "Import Subscription Link";
 "ui.quick.update_remote_configs" = "Update Subscription Links";
 "ui.quick.show_in_finder" = "Show in Finder";
+"ui.quick.config_status.subtitle" = "(Changed: %@, Check succeeded: %@)";
+"ui.quick.config_status.never_checked" = "Never";
+"ui.quick.config_status.just_now" = "just now";
 "ui.quick.remote.url_label" = "Subscription URL";
 "ui.quick.remote.url_placeholder" = "https://example.com/config.yaml";
 "ui.quick.remote.filename_label" = "File Name";

--- a/Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -84,6 +84,9 @@
 "ui.quick.import_remote_config" = "导入订阅链接";
 "ui.quick.update_remote_configs" = "更新订阅链接";
 "ui.quick.show_in_finder" = "在访达中显示";
+"ui.quick.config_status.subtitle" = "(变更:%@, 检查成功:%@)";
+"ui.quick.config_status.never_checked" = "未检查";
+"ui.quick.config_status.just_now" = "刚刚";
 "ui.quick.remote.url_label" = "订阅链接";
 "ui.quick.remote.url_placeholder" = "https://example.com/config.yaml";
 "ui.quick.remote.filename_label" = "文件名";


### PR DESCRIPTION
## 变更说明

本 PR 以最小改动实现配置切换菜单的状态可见性与单项订阅刷新交互：

1. 配置菜单项新增第二行状态
- 展示格式：`(变更:xx, 检查成功:xx)`
- 复用 `AttachedPopoverMenuItem` 的 `subtitle` 两行样式
- 仅在打开“切换配置”菜单时刷新状态快照

2. 远程订阅配置新增单项刷新按钮
- 仅 `remoteConfigSources` 中的配置显示右侧 `arrow.clockwise`
- 点击后复用现有订阅更新链路进行单文件更新
- 增加交互反馈：刷新中（菊花）/成功（绿勾）/失败（红叉）

3. 更新状态与文件变更时间逻辑修正
- 单项/批量订阅更新成功时刷新“检查成功时间”
- 若远程内容与本地文件一致，则不写盘，避免误刷新文件修改时间
- 相对时间显示保证仅“过去时”，近 45 秒统一显示“刚刚/just now”

4. 持久化与数据清理
- 新增远程配置“最后检查成功时间”持久化
- 随配置列表/订阅来源变化自动裁剪无效键

## 变更文件
- `Sources/ClashBar/App/Session/AppSession.swift`
- `Sources/ClashBar/App/Session/Extensions/AppSession+Config.swift`
- `Sources/ClashBar/App/Session/Extensions/AppSession+Persistence.swift`
- `Sources/ClashBar/Features/MenuBar/Proxy/Views/ProxyTabView.swift`
- `Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings`
- `Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings`

## 验证
- `swift build` 通过
- 本地打包 `dist/ClashBar.app` 成功
