### PR TITLE
fix(remote): sync statusText on target switch for speed display

### DIFF
--- a/Sources/ClashBar/App/Session/Coordinators/AppSession+RemoteMachine.swift
+++ b/Sources/ClashBar/App/Session/Coordinators/AppSession+RemoteMachine.swift
@@ -63,6 +63,19 @@ extension AppSession {
             await self.applyPendingAppLaunchSettingsOverlayIfNeeded(syncSystemProxyPort: false)
         }
 
+        // Sync statusText so isRuntimeRunning reflects the active target.
+        // Remote targets have no local process, so coreRepository.isRunning is
+        // always false; statusText is the only signal menuBarSpeedLines uses.
+        switch target {
+        case .remote:
+            self.statusText = (self.apiStatus == .healthy || self.apiStatus == .degraded)
+                ? "Running" : "Stopped"
+        case .local:
+            if !self.coreRepository.isRunning {
+                self.statusText = "Stopped"
+            }
+        }
+
         if self.apiStatus == .healthy || self.apiStatus == .degraded {
             self.startPolling()
         }


### PR DESCRIPTION
### Problem
- Network speed in the status bar always shows `↑0K / ↓0K` when connected to a remote machine, even though the traffic WebSocket stream is active and receiving data.

### Steps to Reproduce
1. Add a remote Mihomo instance in Machine Management
2. Switch to that remote machine
3. Set status bar display mode to "Icon + Speed" or "Speed Only"
4. Observe status bar — speed stays at 0

### Solution
- Root cause: `menuBarSpeedLines` guards on `isRuntimeRunning`, which checks `coreRepository.isRunning` (local process) or `statusText == "Running"`. In remote mode, no local process runs and `switchToMachineTarget` never set `statusText`, so `isRuntimeRunning` was always `false`.
- After the API refresh in `switchToMachineTarget`, sync `statusText` based on target type:
  - Remote: set to `"Running"` when API is healthy/degraded, `"Stopped"` otherwise
  - Local: reset to `"Stopped"` when local core is not running, preventing stale state from a previous remote session

### Testing
- After connecting to a remote machine, the status bar correctly shows real-time network speed
- Switching back to local (with core not running) doesn't incorrectly show speed data
