### PR TITLE
refactor: unify speed formatting logic and adjust display style

### DIFF
--- a/Sources/ClashBar/App/Session/AppSession.swift
+++ b/Sources/ClashBar/App/Session/AppSession.swift
@@ -230,22 +230,7 @@ final class AppSession: ObservableObject {
     }
 
     func compactMenuBarRate(_ bytesPerSecond: Int64) -> String {
-        let normalizedBytes = max(0, bytesPerSecond)
-        if normalizedBytes == 0 {
-            return "0K"
-        }
-
-        var value = Double(normalizedBytes) / 1024
-        let units = ["K", "M", "G", "T"]
-        var unitIndex = 0
-
-        while value >= 1000, unitIndex < units.count - 1 {
-            value /= 1024
-            unitIndex += 1
-        }
-
-        let integer = min(999, max(1, Int(value)))
-        return "\(integer)\(units[unitIndex])"
+        ValueFormatter.speedCompact(bytesPerSecond)
     }
 
     func refreshMenuBarDisplaySnapshotIfNeeded() {

--- a/Sources/ClashBar/App/Session/AppSessionTypes.swift
+++ b/Sources/ClashBar/App/Session/AppSessionTypes.swift
@@ -127,7 +127,7 @@ struct MenuBarSpeedLines: Equatable {
     let up: String
     let down: String
 
-    static let zero = MenuBarSpeedLines(up: "↑0K", down: "↓0K")
+    static let zero = MenuBarSpeedLines(up: "0K↑", down: "0K↓")
 }
 
 struct MenuBarDisplay: Equatable {

--- a/Sources/ClashBar/Features/StatusBar/Views/StatusItemContentView.swift
+++ b/Sources/ClashBar/Features/StatusBar/Views/StatusItemContentView.swift
@@ -7,7 +7,7 @@ final class StatusItemContentView: NSView {
     private let brandIconRenderSize: CGFloat = 24
     private let symbolPointSize: CGFloat = 20
     private let iconTextSpacing: CGFloat = 0
-    private let textContainerWidth: CGFloat = 34
+    private let textContainerWidth: CGFloat = 45
     private let textLineHeight: CGFloat = 11
 
     private let iconView: NSImageView = {

--- a/Sources/ClashBar/Shared/UI/Formatters/Formatters.swift
+++ b/Sources/ClashBar/Shared/UI/Formatters/Formatters.swift
@@ -40,11 +40,30 @@ enum ValueFormatter {
     private static let iso8601BasicKey = "clashbar.formatter.iso8601.basic"
 
     static func speed(_ value: Int64) -> String {
-        let normalized = max(0, value)
-        if normalized >= 1024 * 1024 {
-            return String(format: "%.2f MB/s", Double(normalized) / (1024 * 1024))
+        let (formatted, unit) = speedComponents(value)
+        return "\(formatted) \(unit)/s"
+    }
+
+    static func speedCompact(_ value: Int64) -> String {
+        let (formatted, unit) = speedComponents(value)
+        return "\(formatted)\(unit.replacingOccurrences(of: "B", with: ""))"
+    }
+
+    private static func speedComponents(_ bytesPerSecond: Int64) -> (String, String) {
+        let normalized = max(0, bytesPerSecond)
+        var value = Double(normalized) / 1024
+        let units = ["KB", "MB", "GB", "TB"]
+        var unitIndex = 0
+
+        while value >= 1000, unitIndex < units.count - 1 {
+            value /= 1024
+            unitIndex += 1
         }
-        return String(format: "%.2f KB/s", Double(normalized) / 1024)
+
+        if unitIndex == 0 {
+            return (String(format: "%.0f", value), units[unitIndex])
+        }
+        return (String(format: "%.2f", value), units[unitIndex])
     }
 
     static func bytesInteger(_ value: Int64) -> String {


### PR DESCRIPTION
### Summary
Consolidate scattered speed formatting logic into `ValueFormatter`, unify display precision rules between the status bar and the panel, and adjust the status bar arrow indicator position.

### Changes
- Extract a private `speedComponents` method in `ValueFormatter` to centralize unit conversion and precision strategy (KB as integers, MB and above with two decimal places).
- Add `speedCompact` for status bar use, replacing the duplicated implementation in `AppSession.compactMenuBarRate`.
- Reposition arrow symbols in `MenuBarSpeedLines.zero` from prefix to suffix (`↑0K` → `0K↑`) to align with `speedCompact` output format.
- Widen status bar speed text container from 34pt to 45pt to accommodate the longer formatted output.

<img width="365" height="284" alt="CleanShot 2026-03-28 at 22 54 04" src="https://github.com/user-attachments/assets/f43da2c0-7b2f-4210-aff9-93fc2f33f531" />
