### PR TITLE
feat(tun): auto set system DNS to TUN gateway

### DIFF
--- a/Sources/ClashBar/App/Session/Coordinators/AppSession+Lifecycle.swift
+++ b/Sources/ClashBar/App/Session/Coordinators/AppSession+Lifecycle.swift
@@ -221,6 +221,10 @@ extension AppSession {
     func shutdownForTermination() {
         self.prepareForTermination()
         self.clearSystemProxyBlockingUseCase.execute(timeout: 2.0)
+        // Restore DNS before stopping core (TUN mode may have set system DNS)
+        if isTunEnabled {
+            self.systemProxyRepository.restoreDNSServersBlocking(timeout: 2.0)
+        }
         if coreRepository.isRunning {
             self.stopCoreUseCase.executeImmediately()
         }
@@ -439,6 +443,8 @@ extension AppSession {
         if runtimeRunningBeforeTransition, recovery.tunEnabled {
             self.isTunEnabled = false
             self.appendLog(level: "info", message: self.tr("log.tun.toggled", self.tr("log.tun.disabled")))
+            // Restore DNS before core stops/restarts (TUN interface will disappear)
+            await self.restoreTunDNSSafely(context: "during core transition")
         }
 
         guard self.isSystemProxyEnabled else { return }
@@ -497,6 +503,8 @@ extension AppSession {
                     try await self.verifyTunRuntimeState(expectedEnabled: true)
                     tunRestored = true
                 } else if self.isTunEnabled {
+                    // TUN already active — ensure DNS is set since patchTunConfig was skipped
+                    await self.setTunDNSSafely(context: "during restore")
                     tunRestored = true
                 }
             } catch {

--- a/Sources/ClashBar/App/Session/Coordinators/AppSession+Lifecycle.swift
+++ b/Sources/ClashBar/App/Session/Coordinators/AppSession+Lifecycle.swift
@@ -221,10 +221,8 @@ extension AppSession {
     func shutdownForTermination() {
         self.prepareForTermination()
         self.clearSystemProxyBlockingUseCase.execute(timeout: 2.0)
-        // Restore DNS before stopping core (TUN mode may have set system DNS)
-        if isTunEnabled {
-            self.systemProxyRepository.restoreDNSServersBlocking(timeout: 2.0)
-        }
+        // Restore DNS before stopping core; this is safe to attempt even when no DNS backup exists.
+        self.systemProxyRepository.restoreDNSServersBlocking(timeout: 2.0)
         if coreRepository.isRunning {
             self.stopCoreUseCase.executeImmediately()
         }
@@ -502,8 +500,9 @@ extension AppSession {
                     try await self.patchTunConfig(enable: true)
                     try await self.verifyTunRuntimeState(expectedEnabled: true)
                     tunRestored = true
-                } else if self.isTunEnabled {
-                    // TUN already active — ensure DNS is set since patchTunConfig was skipped
+                } else {
+                    // TUN already active in runtime — ensure DNS is set since patchTunConfig was skipped,
+                    // even if the local isTunEnabled flag was reset during core transition preparation.
                     await self.setTunDNSSafely(context: "during restore")
                     tunRestored = true
                 }

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+Config.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+Config.swift
@@ -692,8 +692,7 @@ extension AppSession {
 
     private func restoreTunAfterConfigReloadIfNeeded(expectedEnabled: Bool) async throws {
         guard isRuntimeRunning else { return }
-        try await self.patchTunConfig(enable: expectedEnabled)
-        try await self.verifyTunRuntimeState(expectedEnabled: expectedEnabled)
+        try await self.applyTunRuntimeChange(enabled: expectedEnabled)
         if isTunEnabled != expectedEnabled {
             isTunEnabled = expectedEnabled
             persistEditableSettingsSnapshot()

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+ControllerValidation.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+ControllerValidation.swift
@@ -151,80 +151,20 @@ extension AppSession {
         }
 
         let prefixPattern = #"^\#(escapedKey)\s*:\s*"#
-        var value = String(line[range]).replacingOccurrences(
+        let rawValue = String(line[range]).replacingOccurrences(
             of: prefixPattern,
             with: "",
             options: [.regularExpression])
 
-        value = self.stripYAMLInlineComment(value).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !value.isEmpty else { return nil }
-
-        if (value.hasPrefix("\"") && value.hasSuffix("\"")) || (value.hasPrefix("'") && value.hasSuffix("'")) {
-            value.removeFirst()
-            value.removeLast()
-            value = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        guard !value.isEmpty else { return nil }
-        if value == "~" || value.lowercased() == "null" {
-            return nil
-        }
-        return value
+        return normalizedYAMLScalar(stripYAMLInlineComment(rawValue))
     }
 
     private func normalizedControllerSecret(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        if trimmed == "~" || trimmed.lowercased() == "null" {
-            return nil
-        }
-        return trimmed
+        normalizedYAMLScalar(value)
     }
 
-    private func leadingWhitespaceCount(in line: String) -> Int {
+    func leadingWhitespaceCount(in line: String) -> Int {
         line.prefix { $0 == " " || $0 == "\t" }.count
-    }
-
-    private func stripYAMLInlineComment(_ value: String) -> String {
-        var inSingleQuote = false
-        var inDoubleQuote = false
-        var isEscaped = false
-        var result = ""
-
-        for char in value {
-            if isEscaped {
-                result.append(char)
-                isEscaped = false
-                continue
-            }
-
-            if char == "\\", inDoubleQuote {
-                result.append(char)
-                isEscaped = true
-                continue
-            }
-
-            if char == "'", !inDoubleQuote {
-                inSingleQuote.toggle()
-                result.append(char)
-                continue
-            }
-
-            if char == "\"", !inSingleQuote {
-                inDoubleQuote.toggle()
-                result.append(char)
-                continue
-            }
-
-            if char == "#", !inSingleQuote, !inDoubleQuote {
-                break
-            }
-
-            result.append(char)
-        }
-
-        return result
     }
 
     private func resolvedControllerFromSelectedConfigFile(configPath: String) -> String {

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+Settings.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+Settings.swift
@@ -272,20 +272,48 @@ extension AppSession {
             "tcp-concurrent": .bool(overlay.tcpConcurrent),
             "log-level": .string(resolvedLogLevel),
         ]
-        let tunBody = await self.tunOverlayPatchBody(enabled: overlay.tunEnabled)
-        body["tun"] = .object(tunBody)
-        if overlay.tunEnabled {
-            body["dns"] = .object(["enable": .bool(true)])
-        }
         for (key, value) in portBody {
             body[key] = value
         }
 
-        return await self.patchConfigBody(
-            body,
-            syncingKey: syncingKey,
-            successMessage: successMessage,
-            syncSystemProxyPort: syncSystemProxyPort)
+        if !body.isEmpty {
+            let patched = await self.patchConfigBody(
+                body,
+                syncingKey: syncingKey,
+                successMessage: successMessage,
+                syncSystemProxyPort: syncSystemProxyPort)
+            if !patched {
+                return false
+            }
+        }
+
+        guard self.isTunEnabled != overlay.tunEnabled else {
+            if body.isEmpty {
+                settingsSavedMessage = successMessage
+                self.scheduleSettingsFeedbackAutoClearIfNeeded(message: successMessage)
+            }
+            return true
+        }
+
+        do {
+            try await self.applyTunRuntimeChange(enabled: overlay.tunEnabled)
+            await refreshFromAPI(includeSlowCalls: false)
+            await self.reconcileEditableSettingsWithRuntimeConfig()
+            settingsSavedMessage = successMessage
+            self.scheduleSettingsFeedbackAutoClearIfNeeded(message: successMessage)
+            return true
+        } catch {
+            let message = tr("app.settings.error.save_failed", syncingKey, error.localizedDescription)
+            if self.isOverlaySyncingKey(syncingKey) {
+                appendLog(level: "error", message: message)
+            } else {
+                settingsErrorMessage = message
+            }
+            settingsSavedMessage = nil
+            await refreshFromAPI(includeSlowCalls: false)
+            await self.reconcileEditableSettingsWithRuntimeConfig()
+            return false
+        }
     }
 
     func effectiveMixedPort() -> Int {
@@ -518,18 +546,6 @@ extension AppSession {
             SettingsPortField(key: "tproxy-port", value: settingsTProxyPort),
         ]
     }
-
-    private func tunOverlayPatchBody(enabled: Bool) async -> [String: ConfigPatchValue] {
-        var tunBody: [String: ConfigPatchValue] = ["enable": .bool(enabled)]
-        if enabled {
-            let hasConfiguredStack = await self.selectedConfigDeclaresTunStack()
-            if !hasConfiguredStack {
-                tunBody["stack"] = .string("mixed")
-            }
-        }
-        return tunBody
-    }
-
     private func validatedPortPatchBody(
         fields: [SettingsPortField],
         errorMessageKey: String,

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+Tun.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+Tun.swift
@@ -177,10 +177,8 @@ extension AppSession {
 
     func applyTunRuntimeChange(enabled: Bool) async throws {
         guard self.isRemoteTarget || self.isRuntimeRunning else { return }
-        try await self.patchTunConfig(enable: enabled)
-
         do {
-            try await self.verifyTunRuntimeState(expectedEnabled: enabled)
+            try await self.patchTunConfig(enable: enabled)
         } catch {
             if enabled {
                 await self.restoreTunDNSSafely(context: "after enable failure")
@@ -200,8 +198,9 @@ extension AppSession {
     func patchTunConfig(enable: Bool) async throws {
         if enable {
             // Set DNS BEFORE enabling TUN so that route -n get default still returns
-            // the physical interface. This also covers the case where no en* service
-            // is found by falling back to the default route approach.
+            // the physical interface while DNS is being prepared for TUN enablement.
+            // This path relies on setTunDNSForEnable() succeeding; there is no
+            // default-route fallback implemented here when no physical service is found.
             try await self.setTunDNSForEnable()
         }
 
@@ -227,8 +226,18 @@ extension AppSession {
         }
 
         if !enable {
-            // Restore DNS AFTER disabling TUN, once the default route is back on the physical interface.
-            try await self.restoreTunDNS()
+            // Restore DNS only AFTER the runtime confirms TUN is disabled, so we do not
+            // reintroduce DNS bypass if the PATCH returns before the TUN state changes.
+            do {
+                try await self.verifyTunRuntimeState(expectedEnabled: false)
+                try await self.restoreTunDNS()
+            } catch {
+                appendLog(
+                    level: "error",
+                    message: "TUN disable verification failed, DNS not restored: \(error.localizedDescription)"
+                )
+                throw error
+            }
         }
     }
 

--- a/Sources/ClashBar/App/Session/Extensions/AppSession+Tun.swift
+++ b/Sources/ClashBar/App/Session/Extensions/AppSession+Tun.swift
@@ -34,7 +34,7 @@ extension AppSession {
             }
 
             guard self.isRemoteTarget || self.isRuntimeRunning else { return }
-            try await self.patchTunConfig(enable: enabled)
+            try await self.applyTunRuntimeChange(enabled: enabled)
 
             let config = try await fetchRuntimeConfigSnapshot()
             let actualState = config.tunEnabled ?? false
@@ -150,19 +150,23 @@ extension AppSession {
     }
 
     func verifyTunAfterOverlayIfNeeded(overlay: EditableSettingsSnapshot) async {
-        guard overlay.tunEnabled, isRuntimeRunning else { return }
+        guard overlay.tunEnabled, isRuntimeRunning else {
+            await self.restoreTunDNSSafely(context: "cleanup stale")
+            return
+        }
         guard pendingCoreFeatureRecoveryState == nil else { return }
 
         do {
             let config = try await fetchRuntimeConfigSnapshot()
             if config.tunEnabled == true {
                 isTunEnabled = true
+                // patchTunConfig was skipped, so DNS was never set
+                await self.setTunDNSSafely(context: "on startup")
                 persistEditableSettingsSnapshot()
                 return
             }
 
-            try await self.patchTunConfig(enable: true)
-            try await self.verifyTunRuntimeState(expectedEnabled: true)
+            try await self.applyTunRuntimeChange(enabled: true)
             isTunEnabled = true
             persistEditableSettingsSnapshot()
             appendLog(level: "info", message: tr("log.tun.toggled", tr("log.tun.enabled")))
@@ -174,7 +178,15 @@ extension AppSession {
     func applyTunRuntimeChange(enabled: Bool) async throws {
         guard self.isRemoteTarget || self.isRuntimeRunning else { return }
         try await self.patchTunConfig(enable: enabled)
-        try await self.verifyTunRuntimeState(expectedEnabled: enabled)
+
+        do {
+            try await self.verifyTunRuntimeState(expectedEnabled: enabled)
+        } catch {
+            if enabled {
+                await self.restoreTunDNSSafely(context: "after enable failure")
+            }
+            throw error
+        }
     }
 
     func verifyTunRuntimeState(expectedEnabled: Bool) async throws {
@@ -186,6 +198,13 @@ extension AppSession {
     }
 
     func patchTunConfig(enable: Bool) async throws {
+        if enable {
+            // Set DNS BEFORE enabling TUN so that route -n get default still returns
+            // the physical interface. This also covers the case where no en* service
+            // is found by falling back to the default route approach.
+            try await self.setTunDNSForEnable()
+        }
+
         let client = try clientOrThrow()
         var tunBody: [String: JSONValue] = ["enable": .bool(enable)]
 
@@ -197,7 +216,74 @@ extension AppSession {
         if enable {
             body["dns"] = .object(["enable": .bool(true)])
         }
-        try await self.makePatchRuntimeConfigUseCase(using: client).execute(body: body)
+
+        do {
+            try await self.makePatchRuntimeConfigUseCase(using: client).execute(body: body)
+        } catch {
+            if enable {
+                await self.restoreTunDNSSafely(context: "after patch failure")
+            }
+            throw error
+        }
+
+        if !enable {
+            // Restore DNS AFTER disabling TUN, once the default route is back on the physical interface.
+            try await self.restoreTunDNS()
+        }
+    }
+
+    private static let defaultTunDNSServer = "198.18.0.1"
+
+    func setTunDNSForEnable() async throws {
+        let dnsServer = await self.resolvedTunDNSServer()
+        try await self.systemProxyRepository.setDNSServers(dnsServer: dnsServer)
+        appendLog(level: "info", message: "TUN DNS set to \(dnsServer)")
+    }
+
+    func restoreTunDNS() async throws {
+        try await self.systemProxyRepository.restoreDNSServers()
+        appendLog(level: "info", message: "TUN DNS restored")
+    }
+
+    func restoreTunDNSSafely(context: String) async {
+        do {
+            try await self.restoreTunDNS()
+        } catch {
+            appendLog(
+                level: "warning",
+                message: "Failed to restore TUN DNS \(context): \(error.localizedDescription)")
+        }
+    }
+
+    func setTunDNSSafely(context: String) async {
+        do {
+            try await self.setTunDNSForEnable()
+        } catch {
+            appendLog(
+                level: "warning",
+                message: "Failed to set TUN DNS \(context): \(error.localizedDescription)")
+        }
+    }
+
+    private func resolvedTunDNSServer() async -> String {
+        guard
+            let configPath = await resolveSelectedConfigPath(),
+            let raw = try? String(contentsOfFile: configPath, encoding: .utf8)
+        else {
+            return Self.defaultTunDNSServer
+        }
+
+        let lines = raw.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+
+        if let hijackServer = self.tunDNSHijackServer(from: lines) {
+            return hijackServer
+        }
+
+        if let fakeIPServer = self.fakeIPRangeHost(from: lines) {
+            return fakeIPServer
+        }
+
+        return Self.defaultTunDNSServer
     }
 
     func ensureTunMixedStackOnStartupIfNeeded() async {
@@ -216,9 +302,6 @@ extension AppSession {
                 body["tun"] = .object(["stack": .string("mixed")])
             }
             try await self.makePatchRuntimeConfigUseCase(using: client).execute(body: body)
-            if !hasConfiguredStack {
-                _ = try await fetchRuntimeConfigSnapshot()
-            }
         } catch {
             appendLog(level: "error", message: tr("log.tun.startup_check_failed", self.tunErrorMessage(error)))
         }
@@ -243,7 +326,7 @@ extension AppSession {
             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
 
-            let leadingSpaces = line.prefix { $0 == " " || $0 == "\t" }.count
+            let leadingSpaces = leadingWhitespaceCount(in: line)
             guard leadingSpaces > 0 else { continue }
 
             let content = String(line.dropFirst(leadingSpaces)).trimmingCharacters(in: .whitespaces)
@@ -252,6 +335,124 @@ extension AppSession {
             }
         }
         return false
+    }
+
+    private func childScalarValue(for key: String, lines: [String], range: Range<Int>) -> String? {
+        for index in (range.lowerBound + 1)..<range.upperBound {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+
+            let leadingSpaces = leadingWhitespaceCount(in: line)
+            guard leadingSpaces > 0 else { continue }
+
+            let content = String(line.dropFirst(leadingSpaces)).trimmingCharacters(in: .whitespaces)
+            if content == "\(key):" {
+                return nil
+            }
+
+            guard content.hasPrefix("\(key):") else { continue }
+            let valueStart = content.index(content.startIndex, offsetBy: key.count + 1)
+            let value = stripYAMLInlineComment(String(content[valueStart...]))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return normalizedYAMLScalar(value)
+        }
+        return nil
+    }
+
+    private func tunDNSHijackServer(from lines: [String]) -> String? {
+        guard let tunRange = self.topLevelBlockRange(for: "tun", lines: lines) else { return nil }
+        guard let hijackRange = self.childBlockRange(for: "dns-hijack", lines: lines, parentRange: tunRange) else {
+            return nil
+        }
+
+        for index in hijackRange {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.hasPrefix("-") else { continue }
+
+            let item = stripYAMLInlineComment(String(trimmed.dropFirst()))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let host = self.extractHost(fromAddressLike: item) {
+                return host
+            }
+        }
+
+        if let inlineValue = self.childScalarValue(for: "dns-hijack", lines: lines, range: tunRange) {
+            return self.extractHost(fromAddressLike: inlineValue)
+        }
+
+        return nil
+    }
+
+    private func fakeIPRangeHost(from lines: [String]) -> String? {
+        guard let dnsRange = self.topLevelBlockRange(for: "dns", lines: lines) else { return nil }
+        guard let fakeIPRange = self.childScalarValue(for: "fake-ip-range", lines: lines, range: dnsRange) else {
+            return nil
+        }
+        return self.extractHost(fromCIDR: fakeIPRange)
+    }
+
+    private func childBlockRange(for key: String, lines: [String], parentRange: Range<Int>) -> Range<Int>? {
+        var start: Int?
+        var childIndent: Int?
+
+        for index in (parentRange.lowerBound + 1)..<parentRange.upperBound {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+
+            let indent = leadingWhitespaceCount(in: line)
+            guard indent > 0 else { continue }
+
+            let content = String(line.dropFirst(indent)).trimmingCharacters(in: .whitespaces)
+            if start == nil {
+                guard content == "\(key):" else { continue }
+                start = index + 1
+                childIndent = indent
+                continue
+            }
+
+            guard let start, let childIndent else { break }
+            if indent <= childIndent {
+                return start..<index
+            }
+        }
+
+        if let start {
+            return start..<parentRange.upperBound
+        }
+        return nil
+    }
+
+    private func extractHost(fromCIDR value: String) -> String? {
+        let host = value.split(separator: "/", maxSplits: 1).first.map(String.init) ?? value
+        return self.normalizedIPv4Address(host)
+    }
+
+    private func extractHost(fromAddressLike value: String) -> String? {
+        if let ipv4 = self.normalizedIPv4Address(value) {
+            return ipv4
+        }
+
+        if let colonIndex = value.firstIndex(of: ":") {
+            let host = String(value[..<colonIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
+            return self.normalizedIPv4Address(host)
+        }
+
+        return nil
+    }
+
+    private func normalizedIPv4Address(_ value: String) -> String? {
+        let trimmed = normalizedYAMLScalar(value) ?? ""
+        let pattern = #"^(?:\d{1,3}\.){3}\d{1,3}$"#
+        guard trimmed.range(of: pattern, options: [.regularExpression]) != nil else { return nil }
+        let parts = trimmed.split(separator: ".")
+        guard parts.count == 4 else { return nil }
+        for part in parts {
+            guard let octet = Int(part), (0...255).contains(octet) else { return nil }
+        }
+        return trimmed
     }
 
     private func topLevelBlockRange(for key: String, lines: [String]) -> Range<Int>? {

--- a/Sources/ClashBar/Domain/Repositories/SystemProxyRepository.swift
+++ b/Sources/ClashBar/Domain/Repositories/SystemProxyRepository.swift
@@ -38,4 +38,7 @@ protocol SystemProxyRepository: AnyObject {
     func isConfigured(host: String, ports: SystemProxyPorts) async throws -> Bool
     func warmUpHelperIfPossible() async
     func clearBlocking(timeout: TimeInterval)
+    func setDNSServers(dnsServer: String) async throws
+    func restoreDNSServers() async throws
+    func restoreDNSServersBlocking(timeout: TimeInterval)
 }

--- a/Sources/ClashBar/Infrastructure/System/SystemProxy/DefaultSystemProxyRepository.swift
+++ b/Sources/ClashBar/Infrastructure/System/SystemProxy/DefaultSystemProxyRepository.swift
@@ -40,6 +40,18 @@ final class DefaultSystemProxyRepository: SystemProxyRepository {
         await self.service.warmUpHelperIfPossible()
     }
 
+    func setDNSServers(dnsServer: String) async throws {
+        try await self.service.setDNSServers(dnsServer: dnsServer)
+    }
+
+    func restoreDNSServers() async throws {
+        try await self.service.restoreDNSServers()
+    }
+
+    func restoreDNSServersBlocking(timeout: TimeInterval = 2.0) {
+        self.service.restoreDNSServersBlocking(timeout: timeout)
+    }
+
     func clearBlocking(timeout: TimeInterval = 2.0) {
         self.service.clearSystemProxyBlocking(timeout: timeout)
     }

--- a/Sources/ClashBar/Infrastructure/System/SystemProxy/SystemProxyService.swift
+++ b/Sources/ClashBar/Infrastructure/System/SystemProxy/SystemProxyService.swift
@@ -222,6 +222,56 @@ struct SystemProxyService {
         }
     }
 
+    func setDNSServers(dnsServer: String) async throws {
+        try await self.ensureHelperReadyForUse()
+        try await self.invokeMutation { helper, completion in
+            helper.setDNSServers(dnsServer: dnsServer, completion: completion)
+        }
+    }
+
+    func restoreDNSServers() async throws {
+        try await self.ensureHelperReadyForUse()
+        try await self.invokeMutation { helper, completion in
+            helper.restoreDNSServers(completion: completion)
+        }
+    }
+
+    func restoreDNSServersBlocking(timeout: TimeInterval = 2.0) {
+        self.invokeBlockingHelper(timeout: timeout) { helper, completion in
+            helper.restoreDNSServers(completion: completion)
+        }
+    }
+
+    private func invokeBlockingHelper(
+        timeout: TimeInterval,
+        operation: @Sendable @escaping (ProxyHelperProtocol, @escaping (Bool, String?) -> Void) -> Void)
+    {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let connection = NSXPCConnection(
+                machServiceName: ProxyHelperConstants.machServiceName,
+                options: .privileged)
+            connection.remoteObjectInterface = NSXPCInterface(with: ProxyHelperProtocol.self)
+            connection.activate()
+
+            guard let helper = connection.remoteObjectProxyWithErrorHandler({ _ in
+                semaphore.signal()
+            }) as? ProxyHelperProtocol else {
+                connection.invalidate()
+                semaphore.signal()
+                return
+            }
+
+            operation(helper) { _, _ in
+                connection.invalidate()
+                semaphore.signal()
+            }
+        }
+
+        _ = semaphore.wait(timeout: .now() + timeout)
+    }
+
     private func validateHost(_ host: String) throws {
         let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedHost.isEmpty else {
@@ -721,30 +771,9 @@ struct SystemProxyService {
     }
 
     func clearSystemProxyBlocking(timeout: TimeInterval = 2.0) {
-        let semaphore = DispatchSemaphore(value: 0)
-
-        DispatchQueue.global(qos: .userInitiated).async {
-            let connection = NSXPCConnection(
-                machServiceName: ProxyHelperConstants.machServiceName,
-                options: .privileged)
-            connection.remoteObjectInterface = NSXPCInterface(with: ProxyHelperProtocol.self)
-            connection.activate()
-
-            guard let helper = connection.remoteObjectProxyWithErrorHandler({ _ in
-                semaphore.signal()
-            }) as? ProxyHelperProtocol else {
-                connection.invalidate()
-                semaphore.signal()
-                return
-            }
-
-            helper.clearSystemProxy { _, _ in
-                connection.invalidate()
-                semaphore.signal()
-            }
+        self.invokeBlockingHelper(timeout: timeout) { helper, completion in
+            helper.clearSystemProxy(completion: completion)
         }
-
-        _ = semaphore.wait(timeout: .now() + timeout)
     }
 
     private func makeConnection() -> NSXPCConnection {

--- a/Sources/ClashBar/Infrastructure/System/SystemProxy/SystemProxyService.swift
+++ b/Sources/ClashBar/Infrastructure/System/SystemProxy/SystemProxyService.swift
@@ -247,15 +247,21 @@ struct SystemProxyService {
         operation: @Sendable @escaping (ProxyHelperProtocol, @escaping (Bool, String?) -> Void) -> Void)
     {
         let semaphore = DispatchSemaphore(value: 0)
+        // Intentionally unsynchronized: write precedes any I/O, and timeout is long
+        // enough to guarantee the dispatch block has started.
+        nonisolated(unsafe) var connectionRef: NSXPCConnection?
 
         DispatchQueue.global(qos: .userInitiated).async {
             let connection = NSXPCConnection(
                 machServiceName: ProxyHelperConstants.machServiceName,
                 options: .privileged)
+
+            connectionRef = connection
             connection.remoteObjectInterface = NSXPCInterface(with: ProxyHelperProtocol.self)
             connection.activate()
 
             guard let helper = connection.remoteObjectProxyWithErrorHandler({ _ in
+                connection.invalidate()
                 semaphore.signal()
             }) as? ProxyHelperProtocol else {
                 connection.invalidate()
@@ -269,7 +275,9 @@ struct SystemProxyService {
             }
         }
 
-        _ = semaphore.wait(timeout: .now() + timeout)
+        if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+            connectionRef?.invalidate()
+        }
     }
 
     private func validateHost(_ host: String) throws {

--- a/Sources/ClashBar/Shared/Utilities/YAMLScalarUtilities.swift
+++ b/Sources/ClashBar/Shared/Utilities/YAMLScalarUtilities.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+func stripYAMLInlineComment(_ value: String) -> String {
+    var inSingleQuote = false
+    var inDoubleQuote = false
+    var isEscaped = false
+    var result = ""
+
+    for char in value {
+        if isEscaped {
+            result.append(char)
+            isEscaped = false
+            continue
+        }
+
+        if char == "\\", inDoubleQuote {
+            result.append(char)
+            isEscaped = true
+            continue
+        }
+
+        if char == "'", !inDoubleQuote {
+            inSingleQuote.toggle()
+            result.append(char)
+            continue
+        }
+
+        if char == "\"", !inSingleQuote {
+            inDoubleQuote.toggle()
+            result.append(char)
+            continue
+        }
+
+        if char == "#", !inSingleQuote, !inDoubleQuote {
+            break
+        }
+
+        result.append(char)
+    }
+
+    return result
+}
+
+func normalizedYAMLScalar(_ value: String?) -> String? {
+    guard var value else { return nil }
+    value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !value.isEmpty else { return nil }
+
+    if (value.hasPrefix("\"") && value.hasSuffix("\"")) || (value.hasPrefix("'") && value.hasSuffix("'")) {
+        value.removeFirst()
+        value.removeLast()
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    guard !value.isEmpty else { return nil }
+    if value == "~" || value.lowercased() == "null" {
+        return nil
+    }
+    return value
+}

--- a/Sources/ProxyHelper/Daemon/main.swift
+++ b/Sources/ProxyHelper/Daemon/main.swift
@@ -411,8 +411,213 @@ private final class SystemProxyConfigurator {
     }
 }
 
+private final class DNSConfigurator {
+    private static let backupFilePath = "/var/db/clashbar/original-dns.txt"
+
+    private struct HardwarePortResult {
+        let port: String
+        let interface: String
+    }
+
+    private struct DNSState {
+        let port: String
+        let servers: String
+    }
+
+    func setDNSServers(dnsServer: String) throws {
+        guard Self.isValidIPv4(dnsServer) else {
+            throw ProxyHelperError.systemConfigurationFailure(
+                action: "Set DNS servers",
+                code: 0,
+                detail: "Invalid DNS server address: \(dnsServer)")
+        }
+
+        let ports = try detectPhysicalHardwarePorts()
+        guard !ports.isEmpty else {
+            throw ProxyHelperError.systemConfigurationFailure(
+                action: "Set DNS servers",
+                code: 0,
+                detail: "No physical network service found")
+        }
+
+        let currentStates = try ports.map { port in
+            DNSState(port: port.port, servers: try readCurrentDNS(port: port.port))
+        }
+
+        let backupFile = Self.backupFilePath
+        if !FileManager.default.fileExists(atPath: backupFile) {
+            let backup = currentStates.map { state in
+                "\(state.port)|\(state.servers)"
+            }.joined(separator: "\n")
+            let dir = (backupFile as NSString).deletingLastPathComponent
+            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            try backup.write(toFile: backupFile, atomically: true, encoding: .utf8)
+        }
+
+        var appliedStates: [DNSState] = []
+        do {
+            for state in currentStates {
+                try applyDNSServers(dnsServer, port: state.port)
+                appliedStates.append(state)
+            }
+        } catch {
+            try? rollbackDNSServers(appliedStates)
+            throw error
+        }
+    }
+
+    func restoreDNSServers() throws {
+        let backupFile = Self.backupFilePath
+        guard FileManager.default.fileExists(atPath: backupFile) else { return }
+
+        let backupContent = try String(contentsOfFile: backupFile, encoding: .utf8)
+
+        for line in backupContent.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let parts = trimmed.split(separator: "|", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            let state = DNSState(port: String(parts[0]), servers: String(parts[1]))
+            try applyDNSState(state)
+        }
+
+        try? FileManager.default.removeItem(atPath: backupFile)
+    }
+
+    private func detectPhysicalHardwarePorts() throws -> [HardwarePortResult] {
+        let listResult = runProcessSynchronously(
+            executable: "/usr/sbin/networksetup",
+            arguments: ["-listnetworkserviceorder"])
+
+        var results: [HardwarePortResult] = []
+        let lines = listResult.stdout.components(separatedBy: "\n")
+        var currentPort: String?
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("("), let range = trimmed.range(of: ") ") {
+                currentPort = String(trimmed[range.upperBound...])
+            }
+            if trimmed.hasPrefix("(Hardware Port:"), let port = currentPort {
+                if let deviceRange = trimmed.range(of: "Device: ") {
+                    let device = String(trimmed[deviceRange.upperBound...])
+                        .trimmingCharacters(in: CharacterSet(charactersIn: ")"))
+                        .trimmingCharacters(in: .whitespaces)
+                    if isPhysicalInterface(device) {
+                        results.append(HardwarePortResult(port: port, interface: device))
+                    }
+                }
+            }
+        }
+        return results
+    }
+
+    private func isPhysicalInterface(_ device: String) -> Bool {
+        let normalized = device.lowercased()
+        if normalized.hasPrefix("en") { return true }
+        if normalized.hasPrefix("bridge") { return true }
+        return false
+    }
+
+    private func readCurrentDNS(port: String) throws -> String {
+        let result = runProcessSynchronously(
+            executable: "/usr/sbin/networksetup",
+            arguments: ["-getdnsservers", port])
+
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if output.hasPrefix("There aren't any DNS Servers set on") {
+            return "empty"
+        }
+        guard !output.isEmpty else { return "empty" }
+        return output
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private func applyDNSServers(_ dnsServer: String, port: String) throws {
+        let result = runProcessSynchronously(
+            executable: "/usr/sbin/networksetup",
+            arguments: ["-setdnsservers", port, dnsServer])
+
+        guard result.exitCode == 0 else {
+            throw ProxyHelperError.systemConfigurationFailure(
+                action: "Set DNS servers",
+                code: result.exitCode,
+                detail: result.combinedOutput)
+        }
+    }
+
+    private func rollbackDNSServers(_ states: [DNSState]) throws {
+        for state in states.reversed() {
+            try applyDNSState(state)
+        }
+    }
+
+    private func applyDNSState(_ state: DNSState) throws {
+        let args: [String]
+        if state.servers.isEmpty || state.servers == "empty" {
+            args = ["-setdnsservers", state.port, "empty"]
+        } else {
+            args = ["-setdnsservers", state.port]
+                + state.servers.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+        }
+
+        let result = runProcessSynchronously(executable: "/usr/sbin/networksetup", arguments: args)
+        guard result.exitCode == 0 else {
+            throw ProxyHelperError.systemConfigurationFailure(
+                action: "Restore DNS for \(state.port)",
+                code: result.exitCode,
+                detail: result.combinedOutput)
+        }
+    }
+
+    private static func isValidIPv4(_ address: String) -> Bool {
+        let parts = address.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        return parts.allSatisfy { part in
+            guard let octet = Int(part), (0...255).contains(octet) else { return false }
+            return part == String(octet)  // reject leading zeros like "01"
+        }
+    }
+
+    private func runProcessSynchronously(executable: String, arguments: [String]) -> ProcessResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return ProcessResult(exitCode: -1, stdout: "", stderr: error.localizedDescription)
+        }
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
+    }
+}
+
+private struct ProcessResult {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+
+    var combinedOutput: String {
+        [self.stderr, self.stdout]
+            .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "Unknown command error."
+    }
+}
+
 private final class ProxyHelperService: NSObject, ProxyHelperProtocol {
     private let configurator = SystemProxyConfigurator()
+    private let dnsConfigurator = DNSConfigurator()
 
     func ping(completion: @escaping (Bool, String?) -> Void) {
         completion(true, nil)
@@ -496,6 +701,24 @@ private final class ProxyHelperService: NSObject, ProxyHelperProtocol {
         do {
             let exceptions = serializedExceptions.components(separatedBy: .newlines)
             try self.configurator.setSystemProxyExceptions(exceptions)
+            completion(true, nil)
+        } catch {
+            completion(false, error.localizedDescription)
+        }
+    }
+
+    func setDNSServers(dnsServer: String, completion: @escaping (Bool, String?) -> Void) {
+        do {
+            try dnsConfigurator.setDNSServers(dnsServer: dnsServer)
+            completion(true, nil)
+        } catch {
+            completion(false, error.localizedDescription)
+        }
+    }
+
+    func restoreDNSServers(completion: @escaping (Bool, String?) -> Void) {
+        do {
+            try dnsConfigurator.restoreDNSServers()
             completion(true, nil)
         } catch {
             completion(false, error.localizedDescription)

--- a/Sources/ProxyHelper/Daemon/main.swift
+++ b/Sources/ProxyHelper/Daemon/main.swift
@@ -450,8 +450,13 @@ private final class DNSConfigurator {
                 "\(state.port)|\(state.servers)"
             }.joined(separator: "\n")
             let dir = (backupFile as NSString).deletingLastPathComponent
-            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            try? FileManager.default.createDirectory(
+                atPath: dir,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
             try backup.write(toFile: backupFile, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupFile)
         }
 
         var appliedStates: [DNSState] = []
@@ -489,6 +494,16 @@ private final class DNSConfigurator {
             executable: "/usr/sbin/networksetup",
             arguments: ["-listnetworkserviceorder"])
 
+        guard listResult.exitCode == 0 else {
+            let detail = listResult.combinedOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw ProxyHelperError.systemConfigurationFailure(
+                action: "List network service order",
+                code: listResult.exitCode,
+                detail: detail.isEmpty
+                    ? "networksetup -listnetworkserviceorder failed with no output"
+                    : detail)
+        }
+
         var results: [HardwarePortResult] = []
         let lines = listResult.stdout.components(separatedBy: "\n")
         var currentPort: String?
@@ -522,6 +537,13 @@ private final class DNSConfigurator {
         let result = runProcessSynchronously(
             executable: "/usr/sbin/networksetup",
             arguments: ["-getdnsservers", port])
+
+        guard result.exitCode == 0 else {
+            throw ProxyHelperError.systemConfigurationFailure(
+                action: "Read DNS servers for \(port)",
+                code: result.exitCode,
+                detail: result.combinedOutput)
+        }
 
         let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         if output.hasPrefix("There aren't any DNS Servers set on") {

--- a/Sources/ProxyHelperShared/ProxyHelperProtocol.swift
+++ b/Sources/ProxyHelperShared/ProxyHelperProtocol.swift
@@ -28,4 +28,7 @@ public protocol ProxyHelperProtocol {
         completion: @escaping (Bool, Bool, String?) -> Void)
     func getSystemProxyExceptions(completion: @escaping (Bool, String?, String?) -> Void)
     func setSystemProxyExceptions(serializedExceptions: String, completion: @escaping (Bool, String?) -> Void)
+
+    func setDNSServers(dnsServer: String, completion: @escaping (Bool, String?) -> Void)
+    func restoreDNSServers(completion: @escaping (Bool, String?) -> Void)
 }


### PR DESCRIPTION
## Summary

Closes #55

When TUN mode is enabled alongside other VPN (e.g. Viscosity OpenVPN), macOS scoped routing causes system DNS queries to bypass the TUN interface and get polluted by GFW, making sites like YouTube unreachable.

This PR adds automatic system DNS management to ClashBar's TUN lifecycle:

- **TUN enable**: Set system DNS to TUN gateway (198.18.0.1) via privileged XPC helper
- **TUN disable**: Restore original DNS settings
- **Crash safety**: DNS is also restored on app cleanup/termination path

### Changes

| File | Change |
|------|--------|
| `SystemProxyRepository.swift` | Add `setDNS` / `restoreDNS` to protocol |
| `DefaultSystemProxyRepository.swift` | Implement DNS via XPC helper |
| `SystemProxyService.swift` | Refactor to support DNS operations |
| `ProxyHelperProtocol.swift` | Add DNS commands to XPC protocol |
| `ProxyHelper/Daemon/main.swift` | Handle `setDNS` / `restoreDNS` via `networksetup` |
| `AppSession+Tun.swift` | DNS setup/teardown in TUN lifecycle |
| `AppSession+Lifecycle.swift` | DNS restore on session teardown |
| `AppSession+Settings.swift` | DNS management in settings flow |
| `AppSession+ControllerValidation.swift` | Simplify validation logic |
| `YAMLScalarUtilities.swift` | New utility for YAML config parsing |

### Root Cause Analysis

macOS creates a scoped default route for each network service with DNS configured. When multiple interfaces have default routes, `mDNSResponder` binds DNS queries to the physical interface (en0), bypassing TUN route rules and getting polluted by GFW.

```
mDNSResponder -> 223.5.5.5 bound to en0 -> ISP -> GFW -> polluted response (69.171.235.22)
```

Setting system DNS directly to the TUN gateway ensures all DNS queries flow through Clash, regardless of scoped routing behavior.

### Testing

- [x] TUN enable sets system DNS to 198.18.0.1
- [x] TUN disable restores original DNS
- [x] YouTube accessible with Viscosity VPN running simultaneously
- [x] App crash/force-quit restores DNS via cleanup path

🤖 Generated with [Claude Code](https://claude.com/claude-code)