### PR TITLE
fix(menu-bar): avoid proxy group flicker on reopen

### DIFF
--- a/Sources/ClashBar/ViewModels/AppViewModel+Lifecycle.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Lifecycle.swift
@@ -283,6 +283,7 @@ extension AppViewModel {
         preserveLocalSettingsOnNextSync = true
         proxyGroups = []
         groupLatencies = [:]
+        proxyHistoryLatestDelay = [:]
         proxyNodeTypes = [:]
         groupLatencyLoading = []
         proxyLatencyTesting = []

--- a/Sources/ClashBar/ViewModels/AppViewModel+Lifecycle.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Lifecycle.swift
@@ -107,6 +107,7 @@ extension AppViewModel {
         cancelPolling()
         statusText = "Stopped"
         apiStatus = .unknown
+        clearProxyPresentation()
         resetTrafficPresentation()
     }
 
@@ -281,12 +282,7 @@ extension AppViewModel {
 
         pendingConfigSwitchOverlaySettings = currentEditableSettingsSnapshot()
         preserveLocalSettingsOnNextSync = true
-        proxyGroups = []
-        groupLatencies = [:]
-        proxyHistoryLatestDelay = [:]
-        proxyNodeTypes = [:]
-        groupLatencyLoading = []
-        proxyLatencyTesting = []
+        clearProxyPresentation()
         appendLog(level: "info", message: tr("log.config.changed_restart"))
         cancelProviderRefresh(reason: "config switch requested")
         await self.restartCore(trigger: .configSwitch)

--- a/Sources/ClashBar/ViewModels/AppViewModel+Polling.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Polling.swift
@@ -250,12 +250,9 @@ extension AppViewModel {
 
         memory = MemorySnapshot(inuse: 0)
 
-        proxyGroups.removeAll(keepingCapacity: false)
         groupLatencyLoading.removeAll(keepingCapacity: false)
         groupLatencies.removeAll(keepingCapacity: false)
         proxyLatencyTesting.removeAll(keepingCapacity: false)
-        proxyHistoryLatestDelay.removeAll(keepingCapacity: false)
-        proxyNodeTypes.removeAll(keepingCapacity: false)
 
         providerProxyCount = 0
         providerRuleCount = 0

--- a/Sources/ClashBar/ViewModels/AppViewModel+Polling.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Polling.swift
@@ -234,6 +234,15 @@ extension AppViewModel {
         self.clearTrafficPresentationHistory()
     }
 
+    func clearProxyPresentation() {
+        proxyGroups = []
+        groupLatencies = [:]
+        proxyHistoryLatestDelay = [:]
+        proxyNodeTypes = [:]
+        groupLatencyLoading = []
+        proxyLatencyTesting = []
+    }
+
     func clearTrafficPresentationHistory() {
         displayUpTotal = 0
         displayDownTotal = 0

--- a/Sources/ClashBar/ViewModels/AppViewModel+RemoteMachine.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+RemoteMachine.swift
@@ -13,12 +13,7 @@ extension AppViewModel {
         self.cancelPolling()
         self.resetTrafficPresentation()
         self.clearAllLogs()
-        self.proxyGroups = []
-        self.groupLatencies = [:]
-        self.proxyHistoryLatestDelay = [:]
-        self.proxyNodeTypes = [:]
-        self.groupLatencyLoading = []
-        self.proxyLatencyTesting = []
+        self.clearProxyPresentation()
         self.ruleItems = []
         self.connectionsStore.connections = []
         self.connectionsStore.connectionsCount = 0

--- a/Sources/ClashBar/ViewModels/AppViewModel+RemoteMachine.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+RemoteMachine.swift
@@ -14,6 +14,11 @@ extension AppViewModel {
         self.resetTrafficPresentation()
         self.clearAllLogs()
         self.proxyGroups = []
+        self.groupLatencies = [:]
+        self.proxyHistoryLatestDelay = [:]
+        self.proxyNodeTypes = [:]
+        self.groupLatencyLoading = []
+        self.proxyLatencyTesting = []
         self.ruleItems = []
         self.connectionsStore.connections = []
         self.connectionsStore.connectionsCount = 0


### PR DESCRIPTION
## Summary

- Retain the last proxy group snapshot when the menu bar panel is hidden.
- Keep clearing transient latency/loading state on panel close.
- Clear proxy group snapshots when switching configs or machine targets to avoid stale data across contexts.

## Why

Previously, closing the menu cleared `proxyGroups`, `proxyHistoryLatestDelay`, and `proxyNodeTypes`. Reopening the panel rendered an empty proxy group section before the async refresh completed, causing a visible flicker.