### PR TITLE
fix(logs): prevent mihomo.log from growing without bound

### DIFF
--- a/Sources/ClashBar/Services/AppLogStore.swift
+++ b/Sources/ClashBar/Services/AppLogStore.swift
@@ -1,11 +1,26 @@
 import Foundation
 
+struct AppLogRotationPolicy {
+    let maxFileSizeBytes: UInt64
+    let maxBackupCount: Int
+
+    static let `default` = AppLogRotationPolicy(
+        maxFileSizeBytes: 10 * 1024 * 1024,
+        maxBackupCount: 5)
+}
+
 struct AppLogStore {
     let logFileURL: URL
+    let rotationPolicy: AppLogRotationPolicy
     /// Reference type: struct copies share the same lock, guaranteeing mutual
     /// exclusion even if the store is passed across actor boundaries or captured
     /// by background tasks. Each distinct `init(logFileURL:)` gets a fresh lock.
     private let ioLock = NSLock()
+
+    init(logFileURL: URL, rotationPolicy: AppLogRotationPolicy = .default) {
+        self.logFileURL = logFileURL
+        self.rotationPolicy = rotationPolicy
+    }
 
     func ensureLogFileExists() {
         if !FileManager.default.fileExists(atPath: self.logFileURL.path) {
@@ -28,6 +43,7 @@ struct AppLogStore {
 
         self.ioLock.withLock {
             self.ensureLogFileExists()
+            self.rotateIfNeeded(incomingDataSize: UInt64(data.count))
             guard let handle = FileHandle(forWritingAtPath: logFileURL.path) else { return }
             defer { handle.closeFile() }
             handle.seekToEndOfFile()
@@ -43,6 +59,49 @@ struct AppLogStore {
                 self.ensureLogFileExists()
             }
         }
+    }
+
+    private func rotateIfNeeded(incomingDataSize: UInt64) {
+        guard self.rotationPolicy.maxFileSizeBytes > 0,
+              self.rotationPolicy.maxBackupCount > 0
+        else { return }
+
+        let currentFileSize = self.fileSize(at: self.logFileURL)
+        guard currentFileSize + incomingDataSize > self.rotationPolicy.maxFileSizeBytes else { return }
+
+        let fileManager = FileManager.default
+        let oldestBackupURL = self.rotatedLogFileURL(index: self.rotationPolicy.maxBackupCount)
+        if fileManager.fileExists(atPath: oldestBackupURL.path) {
+            try? fileManager.removeItem(at: oldestBackupURL)
+        }
+
+        if self.rotationPolicy.maxBackupCount > 1 {
+            for index in stride(from: self.rotationPolicy.maxBackupCount - 1, through: 1, by: -1) {
+                let sourceURL = self.rotatedLogFileURL(index: index)
+                guard fileManager.fileExists(atPath: sourceURL.path) else { continue }
+
+                let destinationURL = self.rotatedLogFileURL(index: index + 1)
+                try? fileManager.moveItem(at: sourceURL, to: destinationURL)
+            }
+        }
+
+        if fileManager.fileExists(atPath: self.logFileURL.path), currentFileSize > 0 {
+            try? fileManager.moveItem(at: self.logFileURL, to: self.rotatedLogFileURL(index: 1))
+        }
+
+        self.ensureLogFileExists()
+    }
+
+    private func rotatedLogFileURL(index: Int) -> URL {
+        URL(fileURLWithPath: "\(self.logFileURL.path).\(index)")
+    }
+
+    private func fileSize(at url: URL) -> UInt64 {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        if let size = attributes?[.size] as? NSNumber {
+            return size.uint64Value
+        }
+        return attributes?[.size] as? UInt64 ?? 0
     }
 
     private static let timestampFormatter: DateFormatter = {


### PR DESCRIPTION
## Summary

- Add size-based log rotation for app-managed log files.
- Prevent `mihomo.log` from growing without bound during long-running sessions.
- Keep a limited number of rotated backups using the `.1`, `.2`, ... suffix pattern.

## Details

`AppLogStore` now applies a default rotation policy before appending new log entries:

- Max size per log file: 10 MB
- Backup count: 5
- Rotation pattern:
  - `mihomo.log`
  - `mihomo.log.1`
  - `mihomo.log.2`
  - ...
  - `mihomo.log.5`

This bounds total disk usage while preserving recent logs for troubleshooting.

Although the issue mainly reports `mihomo.log`, the rotation is implemented in `AppLogStore`, so other app-managed log files such as `clashbar.log` benefit from the same protection.

## Verification

- Ran `swift build`

```text
Build complete!
```

Fixes #77
