### PR TITLE
fix(tun): 关闭 IPv6 时清理 TUN IPv6 地址

### DIFF
--- a/Sources/ClashBar/ViewModels/AppViewModel+Settings.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Settings.swift
@@ -265,7 +265,7 @@ extension AppViewModel {
             "tcp-concurrent": .bool(overlay.tcpConcurrent),
             "log-level": .string(resolvedLogLevel),
         ]
-        let tunBody = await self.tunOverlayPatchBody(enabled: overlay.tunEnabled)
+        let tunBody = await self.tunOverlayPatchBody(enabled: overlay.tunEnabled, ipv6Enabled: overlay.ipv6)
         body["tun"] = .object(tunBody)
         if overlay.tunEnabled {
             body["dns"] = .object(["enable": .bool(true)])

--- a/Sources/ClashBar/ViewModels/AppViewModel+SettingsPatch.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+SettingsPatch.swift
@@ -25,12 +25,28 @@ extension AppViewModel {
     }
 
     func applySettingBool(key: String, value: Bool) async {
+        if key == EditableCoreSetting.ipv6.configKey, isTunEnabled, !value {
+            let tunBody = await self.tunOverlayPatchBody(enabled: isTunEnabled, ipv6Enabled: value)
+            await self.patchSingleConfig(
+                key,
+                value: .bool(value),
+                extraBody: ["tun": .object(tunBody)])
+            return
+        }
+
         await self.patchSingleConfig(key, value: .bool(value))
     }
 
-    func patchSingleConfig(_ key: String, value: ConfigPatchValue) async {
+    func patchSingleConfig(
+        _ key: String,
+        value: ConfigPatchValue,
+        extraBody: [String: ConfigPatchValue] = [:]) async
+    {
+        var body = extraBody
+        body[key] = value
+
         _ = await self.patchConfigBody(
-            [key: value],
+            body,
             syncingKey: key,
             successMessage: tr("app.settings.saved.single_key", key))
     }
@@ -233,13 +249,18 @@ extension AppViewModel {
         ]
     }
 
-    func tunOverlayPatchBody(enabled: Bool) async -> [String: ConfigPatchValue] {
+    func tunOverlayPatchBody(enabled: Bool, ipv6Enabled: Bool? = nil) async -> [String: ConfigPatchValue] {
         var tunBody: [String: ConfigPatchValue] = ["enable": .bool(enabled)]
-        if enabled {
-            let hasConfiguredStack = await self.selectedConfigDeclaresTunStack()
-            if !hasConfiguredStack {
-                tunBody["stack"] = .string("mixed")
-            }
+        guard enabled else { return tunBody }
+
+        let hasConfiguredStack = await self.selectedConfigDeclaresTunStack()
+        if !hasConfiguredStack {
+            tunBody["stack"] = .string("mixed")
+        }
+
+        let hasConfiguredInet6Address = await self.selectedConfigDeclaresTunInet6Address()
+        if !(ipv6Enabled ?? settingsIPv6), !hasConfiguredInet6Address {
+            tunBody["inet6-address"] = .array([])
         }
         return tunBody
     }

--- a/Sources/ClashBar/ViewModels/AppViewModel+Tun.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Tun.swift
@@ -181,8 +181,16 @@ extension AppViewModel {
         let client = try clientOrThrow()
         var tunBody: [String: JSONValue] = ["enable": .bool(enable)]
 
-        if enable, await !self.selectedConfigDeclaresTunStack() {
-            tunBody["stack"] = .string("mixed")
+        if enable {
+            let hasConfiguredStack = await self.selectedConfigDeclaresTunStack()
+            if !hasConfiguredStack {
+                tunBody["stack"] = .string("mixed")
+            }
+
+            let hasConfiguredInet6Address = await self.selectedConfigDeclaresTunInet6Address()
+            if !settingsIPv6, !hasConfiguredInet6Address {
+                tunBody["inet6-address"] = .array([])
+            }
         }
 
         var body: [String: JSONValue] = ["tun": .object(tunBody)]
@@ -227,6 +235,19 @@ extension AppViewModel {
         let lines = raw.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
         guard let tunRange = self.topLevelBlockRange(for: "tun", lines: lines) else { return false }
         return self.childLineExists(for: "stack", lines: lines, range: tunRange)
+    }
+
+    func selectedConfigDeclaresTunInet6Address() async -> Bool {
+        guard
+            let configPath = await resolveSelectedConfigPath(),
+            let raw = try? String(contentsOfFile: configPath, encoding: .utf8)
+        else {
+            return false
+        }
+
+        let lines = raw.replacingOccurrences(of: "\r\n", with: "\n").components(separatedBy: "\n")
+        guard let tunRange = self.topLevelBlockRange(for: "tun", lines: lines) else { return false }
+        return self.childLineExists(for: "inet6-address", lines: lines, range: tunRange)
     }
 
     private func childLineExists(for key: String, lines: [String], range: Range<Int>) -> Bool {

--- a/Sources/ClashBar/ViewModels/AppViewModelTypes.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModelTypes.swift
@@ -47,6 +47,7 @@ enum ConfigPatchValue {
     case int(Int)
     case string(String)
     indirect case object([String: ConfigPatchValue])
+    indirect case array([ConfigPatchValue])
 
     var jsonValue: JSONValue {
         switch self {
@@ -58,6 +59,8 @@ enum ConfigPatchValue {
             .string(value)
         case let .object(value):
             .object(value.mapValues(\.jsonValue))
+        case let .array(value):
+            .array(value.map(\.jsonValue))
         }
     }
 }


### PR DESCRIPTION

### 问题

关闭 IPv6 后，当前只会更新 mihomo 的顶层 `ipv6: false`。

但在 TUN 模式下，运行态里仍可能保留默认的 `tun.inet6-address`，例如 `fdfe:dcba:9876::1/126`，导致 TUN 接口上还有 IPv6 地址和相关路由。

### 修改

- IPv6 关闭时，同步将 `tun.inet6-address` 置为空数组。
- 覆盖开启 TUN、关闭 IPv6、启动/切换配置时恢复 settings overlay 这几个路径。
- 如果配置文件中已经显式声明 `tun.inet6-address`，不覆盖用户配置。
- 为 `ConfigPatchValue` 增加 array 支持。

### 验证

- `swift build`
- `git diff --check`
- `swiftformat . --config .swiftformat --lint`

本机只有 Command Line Tools，没有完整 Xcode SourceKit，因此未运行 `swiftlint`。

另外我在本机用 mihomo API 试过，PATCH `tun.inet6-address: []` 后 TUN 仍保持开启，同时 `utun` 上的 `fdfe:dcba:9876::1/126` 会被清掉。

