### PR TITLE
📝 docs(README): 移除 telegram 徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@
   <a href="https://github.com/Sitoi/ClashBar/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">
     <img alt="License" src="https://img.shields.io/github/license/Sitoi/ClashBar?style=flat-square" />
   </a>
-  <a href="https://t.me/clashbars" target="_blank" rel="noopener noreferrer">
-    <img alt="Telegram" src="https://img.shields.io/badge/Telegram-@clashbars-26A5E4?style=flat-square&logo=telegram&logoColor=white" />
-  </a>
 </p>
 
 <p>

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
-【docs】从 README 头部删除 Telegram 链接徽章
-【docs】减少无效入口，保持展示区更简洁

🔧 chore(pnpm-workspace): 补充根包配置
-【chore】在 workspace 中加入当前目录包定义
-【chore】确保 pnpm 能识别根项目并加载配置