### PR TITLE
fix(app): 订阅更新后必现「系统代理操作失败」—— 配置目录防抖 Task 取消了已开工的内核重启

### DIFF
--- a/Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift
@@ -31,7 +31,12 @@ extension AppViewModel {
         self.configDirectoryDebounceTask?.cancel()
         self.configDirectoryDebounceTask = Task { [weak self] in
             guard await (try? Task.sleep(nanoseconds: delayNanoseconds)) != nil else { return }
-            await self?.handleConfigDirectoryChangesIfNeeded()
+            guard let self, !Task.isCancelled else { return }
+            // 已越过防抖窗口 —— 与令牌解绑, 从此不再被后续文件事件 cancel。
+            // 否则 handleConfigDirectoryChangesIfNeeded() 里的整核重启 + 系统代理恢复
+            // 会被下一个 FSEvent 杀掉, 表现为「系统代理操作失败(cancelled)」。
+            self.configDirectoryDebounceTask = nil
+            await self.handleConfigDirectoryChangesIfNeeded()
         }
     }
 

--- a/docs/content/docs/changelog.mdx
+++ b/docs/content/docs/changelog.mdx
@@ -1,0 +1,9 @@
+---
+title: 更新日志
+description: ClashBar 各版本的功能、优化与修复记录，数据来自仓库根目录 CHANGELOG.md。
+full: true
+---
+
+以下内容由构建时解析仓库根目录 [`CHANGELOG.md`](https://github.com/Sitoi/ClashBar/blob/main/CHANGELOG.md) 自动生成。版本号可跳转到对应 GitHub Release。
+
+<ChangelogTimelineBlock />

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: ClashBar 使用文档
+title: 概览
 description: 在 macOS 菜单栏中管理 Mihomo 配置、节点与网络连接。
 ---
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -15,6 +15,7 @@
     "remote-machine",
     "---帮助---",
     "troubleshooting",
+    "changelog",
     "about"
   ]
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,14 +3,17 @@
   "version": "0.0.6",
   "private": true,
   "scripts": {
+    "changelog:sync": "node scripts/parse-changelog.mjs",
+    "predev": "node scripts/parse-changelog.mjs",
+    "prebuild": "node scripts/parse-changelog.mjs",
     "build": "next build",
     "dev": "next dev",
     "start": "next start",
-    "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
+    "types:check": "node scripts/parse-changelog.mjs && fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx",
-    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-    "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+    "preview": "node scripts/parse-changelog.mjs && opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "deploy": "node scripts/parse-changelog.mjs && opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "upload": "node scripts/parse-changelog.mjs && opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true

--- a/docs/scripts/parse-changelog.mjs
+++ b/docs/scripts/parse-changelog.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Parse repo-root CHANGELOG.md → docs/src/data/changelog.generated.json
+ *
+ * Soft-fail: always writes a JSON file so the docs build can proceed.
+ * On parse/IO failure: { ok: false, error, releases: [] }.
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(docsRoot, '..');
+const sourcePath = path.join(repoRoot, 'CHANGELOG.md');
+const outDir = path.join(docsRoot, 'src', 'data');
+const outPath = path.join(outDir, 'changelog.generated.json');
+
+/** @typedef {'feature' | 'improve' | 'fix'} CategoryKey */
+
+const CATEGORY_HEADINGS = [
+  {
+    key: /** @type {CategoryKey} */ ('feature'),
+    re: /^\*\*[^*]*新增功能/,
+  },
+  {
+    key: /** @type {CategoryKey} */ ('improve'),
+    re: /^\*\*[^*]*优化改进/,
+  },
+  {
+    key: /** @type {CategoryKey} */ ('fix'),
+    re: /^\*\*[^*]*修复问题/,
+  },
+];
+
+const VERSION_RE = /^##\s+(v?\d+\.\d+\.\d+)\s*$/;
+const BADGE_RE = /!\[[^\]]*\]\(https?:\/\/[^)]+\)\s*/g;
+const EMPTY_ITEM_RE = /暂无内容/;
+
+/**
+ * @param {string} markdown
+ * @returns {import('../src/lib/changelog').ChangelogData}
+ */
+function parseChangelog(markdown) {
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  /** @type {import('../src/lib/changelog').ChangelogRelease[]} */
+  const releases = [];
+
+  /** @type {import('../src/lib/changelog').ChangelogRelease | null} */
+  let current = null;
+  /** @type {CategoryKey | null} */
+  let category = null;
+  /** @type {string[]} */
+  let summaryLines = [];
+  let inSummary = false;
+
+  const flushSummary = () => {
+    if (!current) return;
+    // Only apply when we actually collected quote lines; never clobber an
+    // already-written summary with an empty re-flush (e.g. on ### headings).
+    if (summaryLines.length === 0) {
+      inSummary = false;
+      return;
+    }
+    const text = summaryLines
+      .map((line) => line.replace(/^>\s?/, '').trim())
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+    if (text) current.summary = text;
+    summaryLines = [];
+    inSummary = false;
+  };
+
+  const startRelease = (version) => {
+    flushSummary();
+    current = {
+      version: version.startsWith('v') ? version : `v${version}`,
+      summary: '',
+      categories: {
+        feature: [],
+        improve: [],
+        fix: [],
+      },
+    };
+    category = null;
+    releases.push(current);
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const trimmed = line.trim();
+
+    const versionMatch = trimmed.match(VERSION_RE);
+    if (versionMatch) {
+      startRelease(versionMatch[1]);
+      continue;
+    }
+
+    if (!current) continue;
+
+    // Horizontal rule / section chrome — ignore
+    if (trimmed === '---' || trimmed.startsWith('###')) {
+      flushSummary();
+      category = null;
+      continue;
+    }
+
+    // Badges row under version heading
+    if (/^!\[/.test(trimmed) && /shields\.io|img\.shields\.io/.test(trimmed)) {
+      continue;
+    }
+
+    // Blockquote summary
+    if (trimmed.startsWith('>')) {
+      // summary only before categories start
+      if (!category && current.categories.feature.length === 0) {
+        inSummary = true;
+        summaryLines.push(trimmed);
+      }
+      continue;
+    }
+
+    if (inSummary && trimmed === '') {
+      flushSummary();
+      continue;
+    }
+
+    if (inSummary && trimmed !== '') {
+      // non-quote content ends summary
+      flushSummary();
+    }
+
+    // Category heading
+    let matchedCategory = false;
+    for (const heading of CATEGORY_HEADINGS) {
+      if (heading.re.test(trimmed)) {
+        flushSummary();
+        category = heading.key;
+        matchedCategory = true;
+        break;
+      }
+    }
+    if (matchedCategory) continue;
+
+    // List item under a category
+    if (category && trimmed.startsWith('-')) {
+      const itemText = cleanItemText(trimmed.replace(/^-\s*/, ''));
+      if (!itemText || EMPTY_ITEM_RE.test(itemText)) continue;
+      current.categories[category].push({ text: itemText });
+    }
+  }
+
+  flushSummary();
+
+  // Drop releases that somehow have no content at all
+  const nonEmpty = releases.filter((release) => {
+    const { feature, improve, fix } = release.categories;
+    return (
+      release.summary.length > 0 ||
+      feature.length > 0 ||
+      improve.length > 0 ||
+      fix.length > 0
+    );
+  });
+
+  return {
+    ok: true,
+    releases: nonEmpty,
+    generatedAt: new Date().toISOString(),
+    source: 'CHANGELOG.md',
+  };
+}
+
+/**
+ * Strip shields badges and collapse whitespace; keep markdown emphasis.
+ * @param {string} text
+ */
+function cleanItemText(text) {
+  return text
+    .replace(BADGE_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * @param {unknown} error
+ */
+function errorMessage(error) {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/**
+ * @param {import('../src/lib/changelog').ChangelogData} data
+ */
+async function writeOutput(data) {
+  await mkdir(outDir, { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+async function main() {
+  try {
+    const markdown = await readFile(sourcePath, 'utf8');
+    const data = parseChangelog(markdown);
+
+    if (data.releases.length === 0) {
+      await writeOutput({
+        ok: false,
+        error: 'CHANGELOG.md 未解析到任何版本条目',
+        releases: [],
+        generatedAt: new Date().toISOString(),
+        source: 'CHANGELOG.md',
+      });
+      console.warn(
+        `[parse-changelog] warning: no releases parsed from ${sourcePath}`,
+      );
+      return;
+    }
+
+    await writeOutput(data);
+    console.log(
+      `[parse-changelog] wrote ${data.releases.length} releases → ${path.relative(docsRoot, outPath)}`,
+    );
+  } catch (error) {
+    const message = errorMessage(error);
+    await writeOutput({
+      ok: false,
+      error: message,
+      releases: [],
+      generatedAt: new Date().toISOString(),
+      source: 'CHANGELOG.md',
+    });
+    console.warn(`[parse-changelog] soft-fail: ${message}`);
+  }
+}
+
+await main();

--- a/docs/src/components/changelog/index.tsx
+++ b/docs/src/components/changelog/index.tsx
@@ -1,0 +1,11 @@
+import data from '@/data/changelog.generated.json';
+import type { ChangelogData } from '@/lib/changelog';
+import { ChangelogTimeline } from './timeline';
+
+/**
+ * Server entry used from MDX. Loads the build-generated JSON and renders the client timeline.
+ * Soft-fail data (ok: false) is handled inside ChangelogTimeline.
+ */
+export function ChangelogTimelineBlock() {
+  return <ChangelogTimeline data={data as ChangelogData} />;
+}

--- a/docs/src/components/changelog/item-text.tsx
+++ b/docs/src/components/changelog/item-text.tsx
@@ -1,0 +1,95 @@
+import { Fragment, type ReactNode } from 'react';
+import { githubIssueUrl } from '@/lib/changelog';
+
+/**
+ * Render a changelog item string with:
+ * - **bold** → <strong>
+ * - [label](url) → external link
+ * - #123 → GitHub issue link
+ * Plain text otherwise (no raw HTML).
+ */
+export function ChangelogItemText({ text }: { text: string }) {
+  return <>{renderInline(text)}</>;
+}
+
+function renderInline(text: string): ReactNode[] {
+  // Order: links first (may contain bold-looking text), then bold, then issues.
+  const linkParts = text.split(/(\[[^\]]+\]\(https?:\/\/[^)]+\))/g);
+  const nodes: ReactNode[] = [];
+
+  linkParts.forEach((part, linkIndex) => {
+    if (!part) return;
+    const linkMatch = part.match(/^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/);
+    if (linkMatch) {
+      nodes.push(
+        <a
+          key={`l-${linkIndex}`}
+          href={linkMatch[2]}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-fd-primary underline-offset-2 hover:underline"
+        >
+          {linkMatch[1]}
+        </a>,
+      );
+      return;
+    }
+    nodes.push(
+      <Fragment key={`p-${linkIndex}`}>
+        {renderBoldAndIssues(part, `p-${linkIndex}`)}
+      </Fragment>,
+    );
+  });
+
+  return nodes;
+}
+
+function renderBoldAndIssues(text: string, keyPrefix: string): ReactNode[] {
+  const boldParts = text.split(/(\*\*[^*]+\*\*)/g);
+  const nodes: ReactNode[] = [];
+
+  boldParts.forEach((part, boldIndex) => {
+    if (!part) return;
+    if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+      const inner = part.slice(2, -2);
+      nodes.push(
+        <strong
+          key={`${keyPrefix}-b-${boldIndex}`}
+          className="font-semibold text-fd-foreground"
+        >
+          {linkifyIssues(inner, `${keyPrefix}-b-${boldIndex}`)}
+        </strong>,
+      );
+      return;
+    }
+    nodes.push(
+      <Fragment key={`${keyPrefix}-t-${boldIndex}`}>
+        {linkifyIssues(part, `${keyPrefix}-t-${boldIndex}`)}
+      </Fragment>,
+    );
+  });
+
+  return nodes;
+}
+
+function linkifyIssues(text: string, keyPrefix: string): ReactNode[] {
+  const parts = text.split(/(#\d+)/g);
+  return parts.map((part, index) => {
+    const match = part.match(/^#(\d+)$/);
+    if (!match) {
+      return <Fragment key={`${keyPrefix}-${index}`}>{part}</Fragment>;
+    }
+    const issue = Number(match[1]);
+    return (
+      <a
+        key={`${keyPrefix}-${index}`}
+        href={githubIssueUrl(issue)}
+        target="_blank"
+        rel="noreferrer"
+        className="font-medium text-fd-primary underline-offset-2 hover:underline"
+      >
+        #{issue}
+      </a>
+    );
+  });
+}

--- a/docs/src/components/changelog/timeline.tsx
+++ b/docs/src/components/changelog/timeline.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  CHANGELOG_CATEGORIES,
+  CHANGELOG_CATEGORY_META,
+  countFilteredItems,
+  githubReleaseUrl,
+  githubReleasesUrl,
+  type ChangelogCategory,
+  type ChangelogData,
+  type ChangelogRelease,
+} from '@/lib/changelog';
+import { cn } from '@/lib/cn';
+import { ChangelogItemText } from './item-text';
+
+type Props = {
+  data: ChangelogData;
+};
+
+export function ChangelogTimeline({ data }: Props) {
+  const [active, setActive] = useState<Set<ChangelogCategory>>(
+    () => new Set(CHANGELOG_CATEGORIES),
+  );
+  const [openVersions, setOpenVersions] = useState<Set<string>>(() => {
+    const first = data.releases[0]?.version;
+    return first ? new Set([first]) : new Set();
+  });
+
+  const visibleReleases = useMemo(() => {
+    if (active.size === 0) return [];
+    if (active.size === CHANGELOG_CATEGORIES.length) {
+      return data.releases;
+    }
+    return data.releases.filter(
+      (release) => countFilteredItems(release, active) > 0,
+    );
+  }, [data.releases, active]);
+
+  if (!data.ok || data.releases.length === 0) {
+    return <ChangelogFallback error={data.error} />;
+  }
+
+  const toggleCategory = (key: ChangelogCategory) => {
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleVersion = (version: string) => {
+    setOpenVersions((prev) => {
+      const next = new Set(prev);
+      if (next.has(version)) next.delete(version);
+      else next.add(version);
+      return next;
+    });
+  };
+
+  return (
+    <div className="not-prose mt-6 flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="mr-1 text-sm text-fd-muted-foreground">筛选</span>
+        {CHANGELOG_CATEGORIES.map((key) => {
+          const meta = CHANGELOG_CATEGORY_META[key];
+          const on = active.has(key);
+
+          return (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={on}
+              onClick={() => toggleCategory(key)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                on
+                  ? categoryChipOn(key)
+                  : 'border-fd-border bg-fd-secondary/40 text-fd-muted-foreground hover:bg-fd-accent hover:text-fd-accent-foreground',
+              )}
+            >
+              <span
+                className={cn(
+                  'size-1.5 rounded-full',
+                  categoryDot(key),
+                  !on && 'opacity-40',
+                )}
+              />
+              {meta.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <ol className="relative m-0 flex list-none flex-col gap-3 p-0">
+        {visibleReleases.map((release, index) => {
+          const open = openVersions.has(release.version);
+          return (
+            <ReleaseCard
+              key={release.version}
+              release={release}
+              open={open}
+              isLatest={index === 0 && release === data.releases[0]}
+              active={active}
+              onToggle={() => toggleVersion(release.version)}
+            />
+          );
+        })}
+      </ol>
+
+      {visibleReleases.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-fd-border px-4 py-8 text-center text-sm text-fd-muted-foreground">
+          当前筛选下没有匹配的更新条目。
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ChangelogFallback({ error }: { error?: string }) {
+  return (
+    <div className="not-prose mt-6 rounded-xl border border-fd-border bg-fd-secondary/30 p-6">
+      <p className="m-0 text-sm font-medium text-fd-foreground">
+        暂时无法加载更新日志
+      </p>
+      <p className="mt-2 text-sm text-fd-muted-foreground">
+        {error
+          ? `原因：${error}`
+          : '构建时未能解析仓库根目录的 CHANGELOG.md。'}
+        请前往 GitHub Releases 查看完整变更说明。
+      </p>
+      <a
+        href={githubReleasesUrl()}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-4 inline-flex text-sm font-medium text-fd-primary underline-offset-4 hover:underline"
+      >
+        打开 GitHub Releases →
+      </a>
+    </div>
+  );
+}
+
+function ReleaseCard({
+  release,
+  open,
+  isLatest,
+  active,
+  onToggle,
+}: {
+  release: ChangelogRelease;
+  open: boolean;
+  isLatest: boolean;
+  active: ReadonlySet<ChangelogCategory>;
+  onToggle: () => void;
+}) {
+  const itemCount = countFilteredItems(release, active);
+  const panelId = `changelog-${release.version}`;
+
+  return (
+    <li className="rounded-xl border border-fd-border bg-fd-card/40">
+      <div className="flex items-start gap-3 px-4 py-3.5">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={onToggle}
+          className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-fd-border bg-fd-secondary/50 text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+        >
+          <Chevron open={open} />
+        </button>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <a
+              href={githubReleaseUrl(release.version)}
+              target="_blank"
+              rel="noreferrer"
+              className="font-mono text-base font-semibold tracking-tight text-fd-foreground underline-offset-4 hover:underline"
+            >
+              {release.version}
+            </a>
+            {isLatest ? (
+              <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+                最新
+              </span>
+            ) : null}
+            <span className="text-xs text-fd-muted-foreground">
+              {itemCount} 条更新
+            </span>
+          </div>
+
+          {!open && release.summary ? (
+            <p className="mt-1.5 line-clamp-2 text-sm leading-6 text-fd-muted-foreground">
+              <ChangelogItemText text={release.summary} />
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {open ? (
+        <div
+          id={panelId}
+          className="border-t border-fd-border px-4 pb-4 pt-3 sm:px-5"
+        >
+          {release.summary ? (
+            <p className="mb-4 text-sm leading-7 text-fd-muted-foreground">
+              <ChangelogItemText text={release.summary} />
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-4">
+            {CHANGELOG_CATEGORIES.map((key) => {
+              if (!active.has(key)) return null;
+              const items = release.categories[key];
+              if (items.length === 0) return null;
+              const meta = CHANGELOG_CATEGORY_META[key];
+              return (
+                <section key={key}>
+                  <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold text-fd-foreground">
+                    <span
+                      className={cn('size-1.5 rounded-full', categoryDot(key))}
+                    />
+                    {meta.label}
+                    <span className="font-normal text-fd-muted-foreground">
+                      {items.length}
+                    </span>
+                  </h3>
+                  <ul className="m-0 flex list-none flex-col gap-2 p-0">
+                    {items.map((item, i) => (
+                      <li
+                        key={`${key}-${i}`}
+                        className="relative rounded-lg border border-fd-border/70 bg-fd-background/60 px-3 py-2.5 pl-3 text-sm leading-6 text-fd-foreground/90"
+                      >
+                        <ChangelogItemText text={item.text} />
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={cn(
+        'size-3.5 transition-transform duration-150',
+        open && 'rotate-90',
+      )}
+      aria-hidden
+    >
+      <path
+        d="M6 3.5 11 8l-5 4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function categoryDot(key: ChangelogCategory): string {
+  switch (key) {
+    case 'feature':
+      return 'bg-emerald-500';
+    case 'improve':
+      return 'bg-sky-500';
+    case 'fix':
+      return 'bg-rose-500';
+  }
+}
+
+function categoryChipOn(key: ChangelogCategory): string {
+  switch (key) {
+    case 'feature':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
+    case 'improve':
+      return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300';
+    case 'fix':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300';
+  }
+}

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,9 +1,11 @@
+import { ChangelogTimelineBlock } from '@/components/changelog';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    ChangelogTimelineBlock,
     ...components,
   } satisfies MDXComponents;
 }

--- a/docs/src/lib/changelog.ts
+++ b/docs/src/lib/changelog.ts
@@ -1,0 +1,74 @@
+import { gitConfig } from '@/lib/shared';
+
+export type ChangelogCategory = 'feature' | 'improve' | 'fix';
+
+export type ChangelogItem = {
+  text: string;
+};
+
+export type ChangelogRelease = {
+  version: string;
+  summary: string;
+  categories: Record<ChangelogCategory, ChangelogItem[]>;
+};
+
+export type ChangelogData = {
+  ok: boolean;
+  error?: string;
+  releases: ChangelogRelease[];
+  generatedAt: string;
+  source: string;
+};
+
+export const CHANGELOG_CATEGORY_META: Record<
+  ChangelogCategory,
+  { label: string; shortLabel: string; tone: string }
+> = {
+  feature: {
+    label: '新增功能',
+    shortLabel: '功能',
+    tone: 'feature',
+  },
+  improve: {
+    label: '优化改进',
+    shortLabel: '优化',
+    tone: 'improve',
+  },
+  fix: {
+    label: '修复问题',
+    shortLabel: '修复',
+    tone: 'fix',
+  },
+};
+
+export const CHANGELOG_CATEGORIES: ChangelogCategory[] = [
+  'feature',
+  'improve',
+  'fix',
+];
+
+export function githubReleaseUrl(version: string): string {
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  return `https://github.com/${gitConfig.user}/${gitConfig.repo}/releases/tag/${tag}`;
+}
+
+export function githubReleasesUrl(): string {
+  return `https://github.com/${gitConfig.user}/${gitConfig.repo}/releases`;
+}
+
+export function githubIssueUrl(issue: number): string {
+  return `https://github.com/${gitConfig.user}/${gitConfig.repo}/issues/${issue}`;
+}
+
+/** Count items in a release that match the active category filter. */
+export function countFilteredItems(
+  release: ChangelogRelease,
+  active: ReadonlySet<ChangelogCategory>,
+): number {
+  let total = 0;
+  for (const key of CHANGELOG_CATEGORIES) {
+    if (!active.has(key)) continue;
+    total += release.categories[key].length;
+  }
+  return total;
+}

--- a/docs/src/lib/layout.shared.tsx
+++ b/docs/src/lib/layout.shared.tsx
@@ -15,23 +15,8 @@ export function baseOptions(): BaseLayoutProps {
         </span>
       ),
     },
-    links: [
-      {
-        text: "快速开始",
-        url: "/docs/quick-start",
-        active: "nested-url",
-      },
-      {
-        text: "功能总览",
-        url: "/docs/features",
-        active: "nested-url",
-      },
-      {
-        text: "关于",
-        url: "/docs/about",
-        active: "nested-url",
-      },
-    ],
+    // 文档入口统一由侧栏提供；顶栏再列一遍会在移动端抽屉里重复
+    links: [],
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };
 }


### PR DESCRIPTION
# 订阅更新后必现「系统代理操作失败」：配置目录防抖 Task 取消了自己已经开工的内核重启

## 环境

- ClashBar **v0.3.2**（v0.3.0 无此问题，**v0.3.1 开始出现**）
- macOS（Apple Silicon），mihomo v1.19.29
- 系统代理 + TUN 均开启，配置来自远程订阅

## 现象

每次**远程订阅更新**（更新的是当前选中的配置）之后，「系统代理」开关旁必现红字
**「系统代理操作失败」**，且开关被置为关闭。

**手动再点一下开关即恢复正常**，之后一切照旧，直到下次订阅更新再复现。

## 日志（关键证据）

`~/Library/Application Support/clashbar/logs/clashbar.log`：

```
[2026-07-29 11:08:53] [INFO]  配置已变更，正在重启内核
[2026-07-29 11:08:54] [INFO]  系统代理已关闭
[2026-07-29 11:08:55] [ERROR] 切换系统代理失败: cancelled
[2026-07-29 11:08:59] [INFO]  系统代理已开启          ← 手动点开关
```

关键是错误为 **`cancelled`** —— 不是 helper 或 SystemConfiguration 的失败，helper 全程正常。

## 根因

行号基于当前 `main`（`053f691`）。

### 1. 防抖 Task 既是「等待令牌」又是「执行体」

```swift
// Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift:30-36
private func scheduleConfigDirectoryRefresh(delayNanoseconds: UInt64 = 350_000_000) {
    self.configDirectoryDebounceTask?.cancel()          // ← 新事件到达即取消上一个
    self.configDirectoryDebounceTask = Task { [weak self] in
        guard await (try? Task.sleep(nanoseconds: delayNanoseconds)) != nil else { return }
        await self?.handleConfigDirectoryChangesIfNeeded()   // ← 真正的工作在这里面
    }
}
```

`cancel()` 的本意是「上一次还在等待的延迟不必再跑」。
但 `handleConfigDirectoryChangesIfNeeded()` 里包含**整个内核重启 + 重启后的系统代理/TUN 恢复**
（`AppViewModel+ConfigMonitoring.swift:86` → `restartCore(trigger: .configSwitch)`），耗时数秒。

一旦上一个 Task **已越过 `Task.sleep` 进入执行**，后续事件触发的 `cancel()`
杀掉的就不再是「等待」，而是**正在进行的内核重启与恢复流程**。

### 2. 一次文件写入会产生多个事件（两个监听源共用同一令牌）

```swift
// Sources/ClashBar/Services/ConfigDirectoryMonitor.swift
// 源 ①：配置目录
events: [.write, .delete, .extend, .attrib, .link, .rename, .revoke]
// 源 ②：当前选中的配置文件
events: [.write, .delete, .extend, .attrib, .rename, .revoke]
```

两个源共用同一个 `onChange` → 同一个防抖令牌。
订阅更新写入选中的配置文件时，**目录源与文件源都会触发**，而且单次写入本身就会产生
`.write` / `.extend` / `.attrib` 等多个事件。

所以「重启已经开工、随后又来一个事件把它取消」不是偶发竞态，
而是**每次订阅更新几乎必然发生** —— 这解释了为什么现象是 100% 复现的。

### 3. 取消传导进 HTTP 请求

重启完成后的恢复流程：

```swift
// Sources/ClashBar/ViewModels/AppViewModel+Lifecycle.swift:487-515
if recovery.systemProxyEnabled {
    do {
        let target = try await self.resolveSystemProxyTargetFromRuntimeConfig()   // ← 这里
        ...
    } catch {
        self.appendLog(level: "error",
            message: self.tr("log.system_proxy.toggle_failed", self.systemProxyErrorMessage(error)))
        self.updateSystemProxyOpenFailureHint(for: error)                          // ← 红字
        ...
    }
}
```

`resolveSystemProxyTargetFromRuntimeConfig()`（`AppViewModel+SystemProxy.swift:217`）
→ `fetchRuntimeConfigSnapshot()`（`AppViewModel+Polling.swift:200`）
→ `client.request(.getConfigs)` —— 一个打向 mihomo API 的 HTTP 请求。

Swift 中外层 Task 被取消时 `URLSession` 抛 `URLError.cancelled`，
其 `localizedDescription` 正是 `"cancelled"`，与日志逐字吻合。

### 4. 文案把它显示成了「系统代理操作失败」，误导排查方向

```swift
// Sources/ClashBar/ViewModels/AppViewModel+SystemProxy.swift:313-314
func systemProxyFailureHintMessage(for error: Error) -> String {
    guard let serviceError = error as? SystemProxyServiceError else {
        return tr("app.system_proxy.alert.unknown")     // = "系统代理操作失败"
    }
    ...
```

`URLError.cancelled` 不是 `SystemProxyServiceError`，落到兜底分支。
而 `app.system_proxy.alert.unknown` 与 `app.system_proxy.alert.helper_operation_failed`
**文案完全相同**（都是「系统代理操作失败」）。

这会把用户引向「helper 权限 / 注册」方向排查，但实际上 helper 从未失败、甚至没被调用到。

最后 `systemProxyOpenFailureHint` 只在下次操作成功时清除，所以红字一直挂着，
必须手动再点一次开关 —— 与观察完全一致。

## 为什么是 v0.3.1 开始

一开始我以为是「配置变化触发内核重启」这个行为是 v0.3.1 新增的，**但这是错的** ——
v0.3.0 的 `AppViewModel+ConfigMonitoring.swift` 里已经有 `restartCore(trigger: .configSwitch)`。

真正的变化在 commit `45363ea`（`refactor(app): harden runtime state handling`）：
配置目录监控从**轮询**改成了 **FSEvents + 可取消的防抖 Task**。

| 版本 | 机制 | 工作跑在哪个 Task | 会被新事件取消吗 |
|---|---|---|---|
| v0.3.0 | 1 秒轮询 `while` 循环 | 长期存活的循环 Task | **不会** |
| v0.3.1+ | FSEvents + 350ms 防抖 | **每次新建、且会被 cancel 的 Task** | **会** |

也就是说：把热轮询换成事件驱动本身是改进，但**工作体被放进了可取消的防抖 Task**，
于是「防抖取消」意外获得了「中断已开工的重启」的能力。

## 建议修法

核心思路：**防抖令牌只应能取消「还在等待」的那一次，不应能取消「已经开工」的那一次。**

最小改动是让 Task 越过 sleep 之后就与令牌解绑：

```swift
private func scheduleConfigDirectoryRefresh(delayNanoseconds: UInt64 = 350_000_000) {
    self.configDirectoryDebounceTask?.cancel()
    self.configDirectoryDebounceTask = Task { [weak self] in
        guard await (try? Task.sleep(nanoseconds: delayNanoseconds)) != nil else { return }
        guard let self else { return }
        // 已越过防抖窗口 —— 从此不再受后续 cancel 影响
        self.configDirectoryDebounceTask = nil
        await self.handleConfigDirectoryChangesIfNeeded()
    }
}
```

并发重启由 `handleConfigDirectoryChangesIfNeeded()` 里已有的 `isCoreActionProcessing` 判断
兜住（`AppViewModel+ConfigMonitoring.swift:70-77`，会转成 `pendingConfigChangeRestart` 并延后重试）。

另外两点可一并考虑（非必需）：

1. **区分 `app.system_proxy.alert.unknown` 与 `helper_operation_failed` 的文案** ——
   两者当前完全相同，遇到取消类错误时会把人引向 helper 权限方向。

2. **取消类错误或许不该算失败** —— `updateSystemProxyOpenFailureHint(for:)` 之前可先判断
   `error is CancellationError || (error as? URLError)?.code == .cancelled`，
   是取消就不置红字（通常紧接着就会有新一轮处理）。

## 附：一次订阅更新会既热重载又冷重启

顺带一提，订阅更新路径自己已经调过一次热重载：

```swift
// Sources/ClashBar/ViewModels/AppViewModel+RemoteConfig.swift:130-132
if self.shouldAutoReloadCurrentConfig(updatedFileNames: updatedFileNames) {
    await self.reloadConfig()
}
```

而目录监控看到**同一次写入**又会触发一次整核重启，两者的触发条件都是
「变化的是当前选中配置」。这不是本 issue 的直接成因，
但如果订阅更新能抑制掉自己产生的那次目录事件，上述竞态窗口也会一并消失。

## 本 PR 的实现

比上面「建议修法」多一道 `!Task.isCancelled` 自检：cancel 可能恰好落在
sleep 正常结束之后、continuation 排上 MainActor 之前 —— 此刻
`scheduleConfigDirectoryRefresh` 已把令牌指向新一轮任务，旧任务若不自检
就执行 `configDirectoryDebounceTask = nil`，误清的是新任务的令牌。

```swift
guard await (try? Task.sleep(nanoseconds: delayNanoseconds)) != nil else { return }
guard let self, !Task.isCancelled else { return }
self.configDirectoryDebounceTask = nil
await self.handleConfigDirectoryChangesIfNeeded()
```

并发重启仍由 `handleConfigDirectoryChangesIfNeeded()` 里已有的
`isCoreActionProcessing` 分支兜底（转 `pendingConfigChangeRestart` 延后重试），无需额外加锁。

## 真机验证

自编译（Swift 6.2.3 / arm64 / macOS 15.6）装机后，多次触发远程订阅更新：

- 修复前（官方 v0.3.2）：每次必现 `切换系统代理失败: cancelled` + 开关红字
- 修复后：日志稳定为 `配置已变更，正在重启内核` → `系统代理已关闭` → `系统代理已开启`，
  无 `cancelled`、无红字；恢复后系统代理三项（HTTP/HTTPS/SOCKS）均正确指向 mixed-port

感谢维护这个项目 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)
