### PR TITLE
fix(app): 修复快捷命令状态不同步与反馈缺失

### DIFF
--- a/Sources/ClashBar/App/ClashBarApp.swift
+++ b/Sources/ClashBar/App/ClashBarApp.swift
@@ -5,76 +5,88 @@ import SwiftUI
 struct ClashBarApp: App {
     @NSApplicationDelegateAdaptor(ClashBarAppDelegate.self) private var appDelegate
 
-    private var session: AppViewModel {
-        self.appDelegate.appViewModel
-    }
-
     var body: some Scene {
         Settings { EmptyView() }
             .commands {
-                CommandGroup(replacing: .appSettings) {
-                    Button(self.tr("ui.tab.system")) {
-                        self.appDelegate.showSettingsPanel()
-                    }
-                    .keyboardShortcut(",", modifiers: .command)
-                }
-
-                CommandMenu(self.tr("ui.menu.quick")) {
-                    Button(self.tr("ui.quick.system_proxy")) {
-                        Task { await self.session.toggleSystemProxy(!self.session.isSystemProxyEnabled) }
-                    }
-                    .keyboardShortcut("S", modifiers: .command)
-
-                    Button(self.session.isTunEnabled ? self.tr("ui.action.disable_tun") : self
-                        .tr("ui.action.enable_tun"))
-                    {
-                        Task { await self.session.toggleTunMode(!self.session.isTunEnabled) }
-                    }
-                    .keyboardShortcut("E", modifiers: .command)
-                    .disabled(!self.session.isTunToggleEnabled)
-
-                    Divider()
-
-                    // ponytail: ⌘C shadows Edit > Copy while the app is frontmost; ⌘⇧C if that bites
-                    Button(self.tr("ui.quick.copy_terminal")) { self.session.copyLocalProxyCommand() }
-                        .keyboardShortcut("C", modifiers: .command)
-
-                    Button(self.tr("ui.quick.copy_terminal_current_endpoint")) {
-                        self.session.copyManagedEndpointProxyCommand()
-                    }
-                    .keyboardShortcut("C", modifiers: [.command, .option])
-
-                    Divider()
-
-                    Button(self.tr("ui.action.reload_config")) {
-                        Task { await self.session.reloadConfig() }
-                    }
-                    .keyboardShortcut("R", modifiers: .command)
-
-                    Divider()
-
-                    Button(self.session.primaryCoreActionLabel) {
-                        Task { await self.session.performPrimaryCoreAction() }
-                    }
-                    .keyboardShortcut("R", modifiers: [.command, .shift])
-                    .disabled(!self.session.isPrimaryCoreActionEnabled || self.session.isRemoteTarget)
-
-                    Button(self.tr("ui.action.stop")) {
-                        Task { await self.session.stopCore() }
-                    }
-                    .keyboardShortcut(".", modifiers: [.command, .shift])
-                    .disabled(self.session.isRemoteTarget || self.session.isCoreActionProcessing)
-                }
-
-                CommandMenu("Panel") {
-                    ForEach(Self.panelShortcuts, id: \.tab) { entry in
-                        Button(self.tr(entry.key)) { self.session.setActiveMenuTab(entry.tab) }
-                            .keyboardShortcut(entry.shortcut, modifiers: [.command, .option])
-                    }
-                    Button(self.tr("ui.tab.system")) { self.session.setActiveMenuTab(.system) }
-                        .keyboardShortcut("5", modifiers: [.command, .option])
-                }
+                ClashBarCommands(
+                    session: self.appDelegate.appViewModel,
+                    showSettingsPanel: { self.appDelegate.showSettingsPanel() })
             }
+    }
+}
+
+private struct ClashBarCommands: Commands {
+    @ObservedObject private var session: AppViewModel
+    @ObservedObject private var remoteMachineStore: RemoteMachineStore
+    private let showSettingsPanel: () -> Void
+
+    init(session: AppViewModel, showSettingsPanel: @escaping () -> Void) {
+        self.session = session
+        self.remoteMachineStore = session.remoteMachineStore
+        self.showSettingsPanel = showSettingsPanel
+    }
+
+    var body: some Commands {
+        CommandGroup(replacing: .appSettings) {
+            Button(self.tr("ui.tab.system"), action: self.showSettingsPanel)
+                .keyboardShortcut(",", modifiers: .command)
+        }
+
+        CommandMenu(self.tr("ui.menu.quick")) {
+            Button(self.tr("ui.quick.system_proxy")) {
+                Task { await self.session.toggleSystemProxy(!self.session.isSystemProxyEnabled) }
+            }
+            .keyboardShortcut("S", modifiers: .command)
+
+            Button(self.session.isTunEnabled ? self.tr("ui.action.disable_tun") : self
+                .tr("ui.action.enable_tun"))
+            {
+                self.toggleTunMode()
+            }
+            .keyboardShortcut("E", modifiers: .command)
+            .disabled(!self.isTunToggleEnabled)
+
+            Divider()
+
+            // ponytail: ⌘C shadows Edit > Copy while the app is frontmost; ⌘⇧C if that bites
+            Button(self.tr("ui.quick.copy_terminal"), action: self.copyLocalProxyCommand)
+                .keyboardShortcut("C", modifiers: .command)
+
+            Button(self.tr("ui.quick.copy_terminal_current_endpoint")) {
+                self.session.copyManagedEndpointProxyCommand()
+            }
+            .keyboardShortcut("C", modifiers: [.command, .option])
+
+            Divider()
+
+            Button(self.tr("ui.action.reload_config")) {
+                Task { await self.session.reloadConfig() }
+            }
+            .keyboardShortcut("R", modifiers: .command)
+
+            Divider()
+
+            Button(self.session.primaryCoreActionLabel) {
+                Task { await self.session.performPrimaryCoreAction() }
+            }
+            .keyboardShortcut("R", modifiers: [.command, .shift])
+            .disabled(!self.session.isPrimaryCoreActionEnabled || self.isRemoteTarget)
+
+            Button(self.tr("ui.action.stop")) {
+                Task { await self.session.stopCore() }
+            }
+            .keyboardShortcut(".", modifiers: [.command, .shift])
+            .disabled(self.isRemoteTarget || self.session.isCoreActionProcessing)
+        }
+
+        CommandMenu("Panel") {
+            ForEach(Self.panelShortcuts, id: \.tab) { entry in
+                Button(self.tr(entry.key)) { self.session.setActiveMenuTab(entry.tab) }
+                    .keyboardShortcut(entry.shortcut, modifiers: [.command, .option])
+            }
+            Button(self.tr("ui.tab.system")) { self.session.setActiveMenuTab(.system) }
+                .keyboardShortcut("5", modifiers: [.command, .option])
+        }
     }
 
     private static let panelShortcuts: [(tab: RootTab, key: String, shortcut: KeyEquivalent)] = [
@@ -86,5 +98,39 @@ struct ClashBarApp: App {
 
     private func tr(_ key: String) -> String {
         L10n.t(key, language: self.session.uiLanguage)
+    }
+
+    private var isRemoteTarget: Bool {
+        !self.remoteMachineStore.activeTarget.isLocal
+    }
+
+    private var isTunToggleEnabled: Bool {
+        (self.isRemoteTarget || self.session.isRuntimeRunning) && !self.session.isCoreActionProcessing &&
+            !self.session.isTunSyncing
+    }
+
+    private func copyLocalProxyCommand() {
+        let copied = self.session.copyLocalProxyCommand()
+        self.session.statusItemBanner = StatusItemBanner(
+            style: copied ? .success : .error,
+            symbolName: copied ? "doc.on.doc.fill" : "exclamationmark.triangle.fill",
+            title: self.tr("ui.banner.quick_action.title"),
+            primaryDetail: self.tr(copied ? "ui.banner.copy_proxy.success" : "ui.banner.copy_proxy.failure"),
+            secondaryDetail: copied ? self.session.localProxyCommandTargetDisplay() : nil)
+    }
+
+    private func toggleTunMode() {
+        let enabled = !self.session.isTunEnabled
+        Task {
+            let succeeded = await self.session.toggleTunMode(enabled)
+            self.session.statusItemBanner = StatusItemBanner(
+                style: succeeded ? .success : .error,
+                symbolName: succeeded ? "shield.lefthalf.filled" : "exclamationmark.triangle.fill",
+                title: self.tr("ui.banner.quick_action.title"),
+                primaryDetail: self.tr(succeeded
+                    ? (enabled ? "ui.banner.tun.enabled" : "ui.banner.tun.disabled")
+                    : "ui.banner.tun.failure"),
+                secondaryDetail: succeeded ? nil : self.tr("ui.banner.check_logs"))
+        }
     }
 }

--- a/Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings
@@ -100,6 +100,13 @@
 "ui.quick.ssid.disable_auto_switch" = "Disable Wi-Fi Auto Switch";
 "ui.quick.ssid.usage_hint" = "After enabling, right-click a config file to bind.";
 "ui.banner.ssid_strategy.title" = "ClashBar Config Auto Switch";
+"ui.banner.quick_action.title" = "ClashBar Quick Action";
+"ui.banner.copy_proxy.success" = "Proxy command copied";
+"ui.banner.copy_proxy.failure" = "Failed to copy proxy command";
+"ui.banner.tun.enabled" = "TUN mode enabled";
+"ui.banner.tun.disabled" = "TUN mode disabled";
+"ui.banner.tun.failure" = "Failed to switch TUN mode";
+"ui.banner.check_logs" = "Check the logs for details";
 "ui.system_proxy.remote_target_warning" = "System proxy currently points to a remote core. Make sure the remote endpoint remains reachable.";
 
 "ui.section.proxy_providers" = "Proxy Providers";

--- a/Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -102,6 +102,13 @@
 "ui.quick.ssid.disable_auto_switch" = "关闭 Wi-Fi 自动切换";
 "ui.quick.ssid.usage_hint" = "开启后右键配置文件绑定";
 "ui.banner.ssid_strategy.title" = "ClashBar 配置自动切换";
+"ui.banner.quick_action.title" = "ClashBar 快捷操作";
+"ui.banner.copy_proxy.success" = "代理命令已复制";
+"ui.banner.copy_proxy.failure" = "复制代理命令失败";
+"ui.banner.tun.enabled" = "TUN 模式已开启";
+"ui.banner.tun.disabled" = "TUN 模式已关闭";
+"ui.banner.tun.failure" = "TUN 模式切换失败";
+"ui.banner.check_logs" = "请查看日志了解详情";
 "ui.system_proxy.remote_target_warning" = "系统代理当前指向远程内核，请确认远程地址可达。";
 
 "ui.section.proxy_providers" = "代理提供者";

--- a/Sources/ClashBar/ViewModels/AppViewModel+Proxy.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Proxy.swift
@@ -74,15 +74,18 @@ extension AppViewModel {
         }
     }
 
-    func copyProxyCommand() {
+    @discardableResult
+    func copyProxyCommand() -> Bool {
         self.copyLocalProxyCommand()
     }
 
-    func copyLocalProxyCommand() {
+    @discardableResult
+    func copyLocalProxyCommand() -> Bool {
         self.copyProxyCommand(host: "127.0.0.1")
     }
 
-    func copyManagedEndpointProxyCommand() {
+    @discardableResult
+    func copyManagedEndpointProxyCommand() -> Bool {
         self.copyProxyCommand(host: self.managedEndpointProxyCommandHost())
     }
 
@@ -105,13 +108,16 @@ extension AppViewModel {
         self.managedEndpointProxyCommandHost()
     }
 
-    private func copyProxyCommand(host: String) {
+    private func copyProxyCommand(host: String) -> Bool {
         let ports = currentSystemProxyPortsFromState()
         let httpPort = ports.httpPort ?? ports.socksPort ?? effectiveMixedPort()
         let socksPort = ports.socksPort ?? ports.httpPort ?? httpPort
         let script = BuildTerminalProxyCommandUseCase().execute(host: host, httpPort: httpPort, socksPort: socksPort)
-        copyTextToPasteboard(script)
-        appendLog(level: "info", message: tr("log.proxy_export.copied"))
+        let copied = copyTextToPasteboard(script)
+        if copied {
+            appendLog(level: "info", message: tr("log.proxy_export.copied"))
+        }
+        return copied
     }
 
     func switchProxy(group: String, target: String) async {
@@ -370,10 +376,11 @@ extension AppViewModel {
         self.copyAndLog(self.formattedLogEntry(log), message: tr("log.logs.copied_entry"))
     }
 
-    func copyTextToPasteboard(_ text: String) {
+    @discardableResult
+    func copyTextToPasteboard(_ text: String) -> Bool {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        return pasteboard.setString(text, forType: .string)
     }
 
     func formattedLogEntry(_ log: AppErrorLogEntry) -> String {

--- a/Sources/ClashBar/ViewModels/AppViewModel+Tun.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+Tun.swift
@@ -13,9 +13,10 @@ enum TunModeError: LocalizedError {
 
 @MainActor
 extension AppViewModel {
-    func toggleTunMode(_ enabled: Bool) async {
-        guard !isTunSyncing else { return }
-        guard enabled != isTunEnabled else { return }
+    @discardableResult
+    func toggleTunMode(_ enabled: Bool) async -> Bool {
+        guard !isTunSyncing else { return false }
+        guard enabled != isTunEnabled else { return true }
 
         isTunSyncing = true
         defer { isTunSyncing = false }
@@ -25,7 +26,7 @@ extension AppViewModel {
                 try await self.ensureTunPermissions(requestIfMissing: true)
             }
 
-            guard self.isRemoteTarget || self.isRuntimeRunning else { return }
+            guard self.isRemoteTarget || self.isRuntimeRunning else { return false }
             try await self.patchTunConfig(enable: enabled)
 
             let config = try await fetchRuntimeConfigSnapshot()
@@ -37,14 +38,17 @@ extension AppViewModel {
                 appendLog(
                     level: "info",
                     message: tr("log.tun.toggled", enabled ? tr("log.tun.enabled") : tr("log.tun.disabled")))
+                return true
             } else {
                 appendLog(
                     level: "error",
                     message: tr("log.tun.toggle_failed", tr("app.tun.error.runtime_state_mismatch")))
+                return false
             }
         } catch {
             appendLog(level: "error", message: tr("log.tun.toggle_failed", self.tunErrorMessage(error)))
             await self.refreshTunStatusFromRuntimeConfig()
+            return false
         }
     }
 

--- a/Sources/ClashBar/ViewModels/AppViewModelTypes.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModelTypes.swift
@@ -178,12 +178,32 @@ struct MenuBarDisplay: Equatable {
     let isRunning: Bool
 }
 
+enum StatusItemBannerStyle: Equatable {
+    case success
+    case error
+}
+
 struct StatusItemBanner: Equatable, Identifiable {
     let id = UUID()
+    let style: StatusItemBannerStyle
     let symbolName: String
     let title: String
     let primaryDetail: String
     let secondaryDetail: String?
+
+    init(
+        style: StatusItemBannerStyle = .success,
+        symbolName: String,
+        title: String,
+        primaryDetail: String,
+        secondaryDetail: String?)
+    {
+        self.style = style
+        self.symbolName = symbolName
+        self.title = title
+        self.primaryDetail = primaryDetail
+        self.secondaryDetail = secondaryDetail
+    }
 }
 
 struct CoreFeatureRecoveryState {

--- a/Sources/ClashBar/Views/StatusBar/StatusItemController.swift
+++ b/Sources/ClashBar/Views/StatusBar/StatusItemController.swift
@@ -60,7 +60,7 @@ private struct StatusItemBannerRootView: View {
 
                 Spacer(minLength: 0)
 
-                self.successBadge
+                self.resultBadge
                     .frame(width: 48, alignment: .trailing)
             }
 
@@ -163,23 +163,28 @@ private struct StatusItemBannerRootView: View {
         }
     }
 
-    private var successBadge: some View {
+    private var resultBadge: some View {
         ZStack {
             Circle()
-                .stroke(self.nativePositive.opacity(0.9), lineWidth: 2.2)
+                .stroke(self.resultColor.opacity(0.9), lineWidth: 2.2)
                 .background(
                     Circle()
-                        .fill(self.nativePositive.opacity(0.12)))
+                        .fill(self.resultColor.opacity(0.12)))
 
-            Image(systemName: "checkmark")
+            Image(systemName: self.banner.style == .success ? "checkmark" : "xmark")
                 .font(.app(size: T.FontSize.subheadline, weight: .bold))
-                .foregroundStyle(self.nativePositive.opacity(T.Opacity.solid))
+                .foregroundStyle(self.resultColor.opacity(T.Opacity.solid))
         }
         .frame(width: 26, height: 26)
     }
 
+    private var resultColor: Color {
+        self.banner.style == .success ? self.nativePositive : self.nativeCritical
+    }
+
     private var panelTint: Color {
-        self.nativeAccent.opacity(self.isDarkAppearance ? 0.04 : 0.025)
+        let color = self.banner.style == .success ? self.nativeAccent : self.nativeCritical
+        return color.opacity(self.isDarkAppearance ? 0.04 : 0.025)
     }
 
     private var logoBackground: some ShapeStyle {

--- a/docs/content/docs/changelog.mdx
+++ b/docs/content/docs/changelog.mdx
@@ -1,0 +1,9 @@
+---
+title: 更新日志
+description: ClashBar 各版本的功能、优化与修复记录，数据来自仓库根目录 CHANGELOG.md。
+full: true
+---
+
+以下内容由构建时解析仓库根目录 [`CHANGELOG.md`](https://github.com/Sitoi/ClashBar/blob/main/CHANGELOG.md) 自动生成。版本号可跳转到对应 GitHub Release。
+
+<ChangelogTimelineBlock />

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: ClashBar 使用文档
+title: 概览
 description: 在 macOS 菜单栏中管理 Mihomo 配置、节点与网络连接。
 ---
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -15,6 +15,7 @@
     "remote-machine",
     "---帮助---",
     "troubleshooting",
+    "changelog",
     "about"
   ]
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,14 +3,17 @@
   "version": "0.0.6",
   "private": true,
   "scripts": {
+    "changelog:sync": "node scripts/parse-changelog.mjs",
+    "predev": "node scripts/parse-changelog.mjs",
+    "prebuild": "node scripts/parse-changelog.mjs",
     "build": "next build",
     "dev": "next dev",
     "start": "next start",
-    "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
+    "types:check": "node scripts/parse-changelog.mjs && fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx",
-    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-    "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+    "preview": "node scripts/parse-changelog.mjs && opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "deploy": "node scripts/parse-changelog.mjs && opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "upload": "node scripts/parse-changelog.mjs && opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true

--- a/docs/scripts/parse-changelog.mjs
+++ b/docs/scripts/parse-changelog.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Parse repo-root CHANGELOG.md → docs/src/data/changelog.generated.json
+ *
+ * Soft-fail: always writes a JSON file so the docs build can proceed.
+ * On parse/IO failure: { ok: false, error, releases: [] }.
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(docsRoot, '..');
+const sourcePath = path.join(repoRoot, 'CHANGELOG.md');
+const outDir = path.join(docsRoot, 'src', 'data');
+const outPath = path.join(outDir, 'changelog.generated.json');
+
+/** @typedef {'feature' | 'improve' | 'fix'} CategoryKey */
+
+const CATEGORY_HEADINGS = [
+  {
+    key: /** @type {CategoryKey} */ ('feature'),
+    re: /^\*\*[^*]*新增功能/,
+  },
+  {
+    key: /** @type {CategoryKey} */ ('improve'),
+    re: /^\*\*[^*]*优化改进/,
+  },
+  {
+    key: /** @type {CategoryKey} */ ('fix'),
+    re: /^\*\*[^*]*修复问题/,
+  },
+];
+
+const VERSION_RE = /^##\s+(v?\d+\.\d+\.\d+)\s*$/;
+const BADGE_RE = /!\[[^\]]*\]\(https?:\/\/[^)]+\)\s*/g;
+const EMPTY_ITEM_RE = /暂无内容/;
+
+/**
+ * @param {string} markdown
+ * @returns {import('../src/lib/changelog').ChangelogData}
+ */
+function parseChangelog(markdown) {
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  /** @type {import('../src/lib/changelog').ChangelogRelease[]} */
+  const releases = [];
+
+  /** @type {import('../src/lib/changelog').ChangelogRelease | null} */
+  let current = null;
+  /** @type {CategoryKey | null} */
+  let category = null;
+  /** @type {string[]} */
+  let summaryLines = [];
+  let inSummary = false;
+
+  const flushSummary = () => {
+    if (!current) return;
+    // Only apply when we actually collected quote lines; never clobber an
+    // already-written summary with an empty re-flush (e.g. on ### headings).
+    if (summaryLines.length === 0) {
+      inSummary = false;
+      return;
+    }
+    const text = summaryLines
+      .map((line) => line.replace(/^>\s?/, '').trim())
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+    if (text) current.summary = text;
+    summaryLines = [];
+    inSummary = false;
+  };
+
+  const startRelease = (version) => {
+    flushSummary();
+    current = {
+      version: version.startsWith('v') ? version : `v${version}`,
+      summary: '',
+      categories: {
+        feature: [],
+        improve: [],
+        fix: [],
+      },
+    };
+    category = null;
+    releases.push(current);
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const trimmed = line.trim();
+
+    const versionMatch = trimmed.match(VERSION_RE);
+    if (versionMatch) {
+      startRelease(versionMatch[1]);
+      continue;
+    }
+
+    if (!current) continue;
+
+    // Horizontal rule / section chrome — ignore
+    if (trimmed === '---' || trimmed.startsWith('###')) {
+      flushSummary();
+      category = null;
+      continue;
+    }
+
+    // Badges row under version heading
+    if (/^!\[/.test(trimmed) && /shields\.io|img\.shields\.io/.test(trimmed)) {
+      continue;
+    }
+
+    // Blockquote summary
+    if (trimmed.startsWith('>')) {
+      // summary only before categories start
+      if (!category && current.categories.feature.length === 0) {
+        inSummary = true;
+        summaryLines.push(trimmed);
+      }
+      continue;
+    }
+
+    if (inSummary && trimmed === '') {
+      flushSummary();
+      continue;
+    }
+
+    if (inSummary && trimmed !== '') {
+      // non-quote content ends summary
+      flushSummary();
+    }
+
+    // Category heading
+    let matchedCategory = false;
+    for (const heading of CATEGORY_HEADINGS) {
+      if (heading.re.test(trimmed)) {
+        flushSummary();
+        category = heading.key;
+        matchedCategory = true;
+        break;
+      }
+    }
+    if (matchedCategory) continue;
+
+    // List item under a category
+    if (category && trimmed.startsWith('-')) {
+      const itemText = cleanItemText(trimmed.replace(/^-\s*/, ''));
+      if (!itemText || EMPTY_ITEM_RE.test(itemText)) continue;
+      current.categories[category].push({ text: itemText });
+    }
+  }
+
+  flushSummary();
+
+  // Drop releases that somehow have no content at all
+  const nonEmpty = releases.filter((release) => {
+    const { feature, improve, fix } = release.categories;
+    return (
+      release.summary.length > 0 ||
+      feature.length > 0 ||
+      improve.length > 0 ||
+      fix.length > 0
+    );
+  });
+
+  return {
+    ok: true,
+    releases: nonEmpty,
+    generatedAt: new Date().toISOString(),
+    source: 'CHANGELOG.md',
+  };
+}
+
+/**
+ * Strip shields badges and collapse whitespace; keep markdown emphasis.
+ * @param {string} text
+ */
+function cleanItemText(text) {
+  return text
+    .replace(BADGE_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * @param {unknown} error
+ */
+function errorMessage(error) {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/**
+ * @param {import('../src/lib/changelog').ChangelogData} data
+ */
+async function writeOutput(data) {
+  await mkdir(outDir, { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+async function main() {
+  try {
+    const markdown = await readFile(sourcePath, 'utf8');
+    const data = parseChangelog(markdown);
+
+    if (data.releases.length === 0) {
+      await writeOutput({
+        ok: false,
+        error: 'CHANGELOG.md 未解析到任何版本条目',
+        releases: [],
+        generatedAt: new Date().toISOString(),
+        source: 'CHANGELOG.md',
+      });
+      console.warn(
+        `[parse-changelog] warning: no releases parsed from ${sourcePath}`,
+      );
+      return;
+    }
+
+    await writeOutput(data);
+    console.log(
+      `[parse-changelog] wrote ${data.releases.length} releases → ${path.relative(docsRoot, outPath)}`,
+    );
+  } catch (error) {
+    const message = errorMessage(error);
+    await writeOutput({
+      ok: false,
+      error: message,
+      releases: [],
+      generatedAt: new Date().toISOString(),
+      source: 'CHANGELOG.md',
+    });
+    console.warn(`[parse-changelog] soft-fail: ${message}`);
+  }
+}
+
+await main();

--- a/docs/src/components/changelog/index.tsx
+++ b/docs/src/components/changelog/index.tsx
@@ -1,0 +1,11 @@
+import data from '@/data/changelog.generated.json';
+import type { ChangelogData } from '@/lib/changelog';
+import { ChangelogTimeline } from './timeline';
+
+/**
+ * Server entry used from MDX. Loads the build-generated JSON and renders the client timeline.
+ * Soft-fail data (ok: false) is handled inside ChangelogTimeline.
+ */
+export function ChangelogTimelineBlock() {
+  return <ChangelogTimeline data={data as ChangelogData} />;
+}

--- a/docs/src/components/changelog/item-text.tsx
+++ b/docs/src/components/changelog/item-text.tsx
@@ -1,0 +1,95 @@
+import { Fragment, type ReactNode } from 'react';
+import { githubIssueUrl } from '@/lib/changelog';
+
+/**
+ * Render a changelog item string with:
+ * - **bold** → <strong>
+ * - [label](url) → external link
+ * - #123 → GitHub issue link
+ * Plain text otherwise (no raw HTML).
+ */
+export function ChangelogItemText({ text }: { text: string }) {
+  return <>{renderInline(text)}</>;
+}
+
+function renderInline(text: string): ReactNode[] {
+  // Order: links first (may contain bold-looking text), then bold, then issues.
+  const linkParts = text.split(/(\[[^\]]+\]\(https?:\/\/[^)]+\))/g);
+  const nodes: ReactNode[] = [];
+
+  linkParts.forEach((part, linkIndex) => {
+    if (!part) return;
+    const linkMatch = part.match(/^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/);
+    if (linkMatch) {
+      nodes.push(
+        <a
+          key={`l-${linkIndex}`}
+          href={linkMatch[2]}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-fd-primary underline-offset-2 hover:underline"
+        >
+          {linkMatch[1]}
+        </a>,
+      );
+      return;
+    }
+    nodes.push(
+      <Fragment key={`p-${linkIndex}`}>
+        {renderBoldAndIssues(part, `p-${linkIndex}`)}
+      </Fragment>,
+    );
+  });
+
+  return nodes;
+}
+
+function renderBoldAndIssues(text: string, keyPrefix: string): ReactNode[] {
+  const boldParts = text.split(/(\*\*[^*]+\*\*)/g);
+  const nodes: ReactNode[] = [];
+
+  boldParts.forEach((part, boldIndex) => {
+    if (!part) return;
+    if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+      const inner = part.slice(2, -2);
+      nodes.push(
+        <strong
+          key={`${keyPrefix}-b-${boldIndex}`}
+          className="font-semibold text-fd-foreground"
+        >
+          {linkifyIssues(inner, `${keyPrefix}-b-${boldIndex}`)}
+        </strong>,
+      );
+      return;
+    }
+    nodes.push(
+      <Fragment key={`${keyPrefix}-t-${boldIndex}`}>
+        {linkifyIssues(part, `${keyPrefix}-t-${boldIndex}`)}
+      </Fragment>,
+    );
+  });
+
+  return nodes;
+}
+
+function linkifyIssues(text: string, keyPrefix: string): ReactNode[] {
+  const parts = text.split(/(#\d+)/g);
+  return parts.map((part, index) => {
+    const match = part.match(/^#(\d+)$/);
+    if (!match) {
+      return <Fragment key={`${keyPrefix}-${index}`}>{part}</Fragment>;
+    }
+    const issue = Number(match[1]);
+    return (
+      <a
+        key={`${keyPrefix}-${index}`}
+        href={githubIssueUrl(issue)}
+        target="_blank"
+        rel="noreferrer"
+        className="font-medium text-fd-primary underline-offset-2 hover:underline"
+      >
+        #{issue}
+      </a>
+    );
+  });
+}

--- a/docs/src/components/changelog/timeline.tsx
+++ b/docs/src/components/changelog/timeline.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  CHANGELOG_CATEGORIES,
+  CHANGELOG_CATEGORY_META,
+  countFilteredItems,
+  githubReleaseUrl,
+  githubReleasesUrl,
+  type ChangelogCategory,
+  type ChangelogData,
+  type ChangelogRelease,
+} from '@/lib/changelog';
+import { cn } from '@/lib/cn';
+import { ChangelogItemText } from './item-text';
+
+type Props = {
+  data: ChangelogData;
+};
+
+export function ChangelogTimeline({ data }: Props) {
+  const [active, setActive] = useState<Set<ChangelogCategory>>(
+    () => new Set(CHANGELOG_CATEGORIES),
+  );
+  const [openVersions, setOpenVersions] = useState<Set<string>>(() => {
+    const first = data.releases[0]?.version;
+    return first ? new Set([first]) : new Set();
+  });
+
+  const visibleReleases = useMemo(() => {
+    if (active.size === 0) return [];
+    if (active.size === CHANGELOG_CATEGORIES.length) {
+      return data.releases;
+    }
+    return data.releases.filter(
+      (release) => countFilteredItems(release, active) > 0,
+    );
+  }, [data.releases, active]);
+
+  if (!data.ok || data.releases.length === 0) {
+    return <ChangelogFallback error={data.error} />;
+  }
+
+  const toggleCategory = (key: ChangelogCategory) => {
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleVersion = (version: string) => {
+    setOpenVersions((prev) => {
+      const next = new Set(prev);
+      if (next.has(version)) next.delete(version);
+      else next.add(version);
+      return next;
+    });
+  };
+
+  return (
+    <div className="not-prose mt-6 flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="mr-1 text-sm text-fd-muted-foreground">筛选</span>
+        {CHANGELOG_CATEGORIES.map((key) => {
+          const meta = CHANGELOG_CATEGORY_META[key];
+          const on = active.has(key);
+
+          return (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={on}
+              onClick={() => toggleCategory(key)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+                on
+                  ? categoryChipOn(key)
+                  : 'border-fd-border bg-fd-secondary/40 text-fd-muted-foreground hover:bg-fd-accent hover:text-fd-accent-foreground',
+              )}
+            >
+              <span
+                className={cn(
+                  'size-1.5 rounded-full',
+                  categoryDot(key),
+                  !on && 'opacity-40',
+                )}
+              />
+              {meta.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <ol className="relative m-0 flex list-none flex-col gap-3 p-0">
+        {visibleReleases.map((release, index) => {
+          const open = openVersions.has(release.version);
+          return (
+            <ReleaseCard
+              key={release.version}
+              release={release}
+              open={open}
+              isLatest={index === 0 && release === data.releases[0]}
+              active={active}
+              onToggle={() => toggleVersion(release.version)}
+            />
+          );
+        })}
+      </ol>
+
+      {visibleReleases.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-fd-border px-4 py-8 text-center text-sm text-fd-muted-foreground">
+          当前筛选下没有匹配的更新条目。
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ChangelogFallback({ error }: { error?: string }) {
+  return (
+    <div className="not-prose mt-6 rounded-xl border border-fd-border bg-fd-secondary/30 p-6">
+      <p className="m-0 text-sm font-medium text-fd-foreground">
+        暂时无法加载更新日志
+      </p>
+      <p className="mt-2 text-sm text-fd-muted-foreground">
+        {error
+          ? `原因：${error}`
+          : '构建时未能解析仓库根目录的 CHANGELOG.md。'}
+        请前往 GitHub Releases 查看完整变更说明。
+      </p>
+      <a
+        href={githubReleasesUrl()}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-4 inline-flex text-sm font-medium text-fd-primary underline-offset-4 hover:underline"
+      >
+        打开 GitHub Releases →
+      </a>
+    </div>
+  );
+}
+
+function ReleaseCard({
+  release,
+  open,
+  isLatest,
+  active,
+  onToggle,
+}: {
+  release: ChangelogRelease;
+  open: boolean;
+  isLatest: boolean;
+  active: ReadonlySet<ChangelogCategory>;
+  onToggle: () => void;
+}) {
+  const itemCount = countFilteredItems(release, active);
+  const panelId = `changelog-${release.version}`;
+
+  return (
+    <li className="rounded-xl border border-fd-border bg-fd-card/40">
+      <div className="flex items-start gap-3 px-4 py-3.5">
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={onToggle}
+          className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-fd-border bg-fd-secondary/50 text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+        >
+          <Chevron open={open} />
+        </button>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <a
+              href={githubReleaseUrl(release.version)}
+              target="_blank"
+              rel="noreferrer"
+              className="font-mono text-base font-semibold tracking-tight text-fd-foreground underline-offset-4 hover:underline"
+            >
+              {release.version}
+            </a>
+            {isLatest ? (
+              <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+                最新
+              </span>
+            ) : null}
+            <span className="text-xs text-fd-muted-foreground">
+              {itemCount} 条更新
+            </span>
+          </div>
+
+          {!open && release.summary ? (
+            <p className="mt-1.5 line-clamp-2 text-sm leading-6 text-fd-muted-foreground">
+              <ChangelogItemText text={release.summary} />
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {open ? (
+        <div
+          id={panelId}
+          className="border-t border-fd-border px-4 pb-4 pt-3 sm:px-5"
+        >
+          {release.summary ? (
+            <p className="mb-4 text-sm leading-7 text-fd-muted-foreground">
+              <ChangelogItemText text={release.summary} />
+            </p>
+          ) : null}
+
+          <div className="flex flex-col gap-4">
+            {CHANGELOG_CATEGORIES.map((key) => {
+              if (!active.has(key)) return null;
+              const items = release.categories[key];
+              if (items.length === 0) return null;
+              const meta = CHANGELOG_CATEGORY_META[key];
+              return (
+                <section key={key}>
+                  <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold text-fd-foreground">
+                    <span
+                      className={cn('size-1.5 rounded-full', categoryDot(key))}
+                    />
+                    {meta.label}
+                    <span className="font-normal text-fd-muted-foreground">
+                      {items.length}
+                    </span>
+                  </h3>
+                  <ul className="m-0 flex list-none flex-col gap-2 p-0">
+                    {items.map((item, i) => (
+                      <li
+                        key={`${key}-${i}`}
+                        className="relative rounded-lg border border-fd-border/70 bg-fd-background/60 px-3 py-2.5 pl-3 text-sm leading-6 text-fd-foreground/90"
+                      >
+                        <ChangelogItemText text={item.text} />
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function Chevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={cn(
+        'size-3.5 transition-transform duration-150',
+        open && 'rotate-90',
+      )}
+      aria-hidden
+    >
+      <path
+        d="M6 3.5 11 8l-5 4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function categoryDot(key: ChangelogCategory): string {
+  switch (key) {
+    case 'feature':
+      return 'bg-emerald-500';
+    case 'improve':
+      return 'bg-sky-500';
+    case 'fix':
+      return 'bg-rose-500';
+  }
+}
+
+function categoryChipOn(key: ChangelogCategory): string {
+  switch (key) {
+    case 'feature':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
+    case 'improve':
+      return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300';
+    case 'fix':
+      return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300';
+  }
+}

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,9 +1,11 @@
+import { ChangelogTimelineBlock } from '@/components/changelog';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    ChangelogTimelineBlock,
     ...components,
   } satisfies MDXComponents;
 }

--- a/docs/src/lib/changelog.ts
+++ b/docs/src/lib/changelog.ts
@@ -1,0 +1,74 @@
+import { gitConfig } from '@/lib/shared';
+
+export type ChangelogCategory = 'feature' | 'improve' | 'fix';
+
+export type ChangelogItem = {
+  text: string;
+};
+
+export type ChangelogRelease = {
+  version: string;
+  summary: string;
+  categories: Record<ChangelogCategory, ChangelogItem[]>;
+};
+
+export type ChangelogData = {
+  ok: boolean;
+  error?: string;
+  releases: ChangelogRelease[];
+  generatedAt: string;
+  source: string;
+};
+
+export const CHANGELOG_CATEGORY_META: Record<
+  ChangelogCategory,
+  { label: string; shortLabel: string; tone: string }
+> = {
+  feature: {
+    label: '新增功能',
+    shortLabel: '功能',
+    tone: 'feature',
+  },
+  improve: {
+    label: '优化改进',
+    shortLabel: '优化',
+    tone: 'improve',
+  },
+  fix: {
+    label: '修复问题',
+    shortLabel: '修复',
+    tone: 'fix',
+  },
+};
+
+export const CHANGELOG_CATEGORIES: ChangelogCategory[] = [
+  'feature',
+  'improve',
+  'fix',
+];
+
+export function githubReleaseUrl(version: string): string {
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  return `https://github.com/${gitConfig.user}/${gitConfig.repo}/releases/tag/${tag}`;
+}
+
+export function githubReleasesUrl(): string {
+  return `https://github.com/${gitConfig.user}/${gitConfig.repo}/releases`;
+}
+
+export function githubIssueUrl(issue: number): string {
+  return `https://github.com/${gitConfig.user}/${gitConfig.repo}/issues/${issue}`;
+}
+
+/** Count items in a release that match the active category filter. */
+export function countFilteredItems(
+  release: ChangelogRelease,
+  active: ReadonlySet<ChangelogCategory>,
+): number {
+  let total = 0;
+  for (const key of CHANGELOG_CATEGORIES) {
+    if (!active.has(key)) continue;
+    total += release.categories[key].length;
+  }
+  return total;
+}

--- a/docs/src/lib/layout.shared.tsx
+++ b/docs/src/lib/layout.shared.tsx
@@ -15,23 +15,8 @@ export function baseOptions(): BaseLayoutProps {
         </span>
       ),
     },
-    links: [
-      {
-        text: "快速开始",
-        url: "/docs/quick-start",
-        active: "nested-url",
-      },
-      {
-        text: "功能总览",
-        url: "/docs/features",
-        active: "nested-url",
-      },
-      {
-        text: "关于",
-        url: "/docs/about",
-        active: "nested-url",
-      },
-    ],
+    // 文档入口统一由侧栏提供；顶栏再列一遍会在移动端抽屉里重复
+    links: [],
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };
 }


### PR DESCRIPTION
## 问题

在官方 `v0.3.2` 中，点击 ClashBar 面板后：

- `⌘C` 可以正常复制终端代理命令；
- `⌘E` 无法切换 TUN；
- 两个快捷操作都没有可见反馈。

通过 macOS 辅助功能树复现时，内核已运行且面板内 TUN 开关可用，但“快捷操作”菜单仍显示：

- `(disabled) 开启 TUN 模式`
- `启动内核`

与此同时，面板显示的却是可点击的 TUN 开关和“重启内核”。

## 根因

`ClashBarApp` 中的 SwiftUI `CommandMenu` 通过 `appDelegate.appViewModel` 间接读取状态，但命令本身没有观察 `AppViewModel` 和 `RemoteMachineStore`。

因此命令菜单保留应用启动时的状态：无动态禁用条件的 `⌘C` 仍能执行，而依赖 `isTunToggleEnabled` 的 `⌘E` 一直被旧状态禁用。

## 修改

- 将菜单命令提取为独立 `Commands`，观察运行态与远程目标变化；
- 实时更新 TUN 启用状态、TUN 标题及内核启动/重启状态；
- 让 TUN 切换返回实际执行结果，避免提示误报；
- 让剪贴板写入返回结果；
- 复用现有状态栏顶部浮层，为 `⌘C` 和 `⌘E` 展示成功或失败提示；
- 扩展浮层错误样式并补充中英文文案；
- 鼠标点击面板内开关和复制按钮的现有反馈保持不变。

快捷键仍然只在 ClashBar 处于前台时生效，本 PR 不增加系统全局热键。

## 验证

- `git diff --check`
- `plutil -lint Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings`
- 完整 `swift build` 通过


## 关联

`⌘E` 最初由 `00bc7329` 引入；当前没有可直接复用的上游修复 PR。
