### PR TITLE
docs(README): 修复失效的 Star 趋势图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ make dist WITH_CORE=1      # app + dmg
 
 ## ⭐ Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Sitoi/ClashBar&type=date&legend=top-left)](https://www.star-history.com/#Sitoi/ClashBar&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Sitoi/ClashBar&type=date&legend=top-left)](https://star-history.dera.page/#Sitoi/ClashBar&type=date&legend=top-left)


### PR DESCRIPTION
## 问题

README 中的 Star 趋势图表当前已失效，无法正常渲染，原因是 GitHub stargazer API 的限制导致原有数据源不可用。

## 修复

将 Star 趋势图表切换到新的数据源并更新对应跳转链接，使图表恢复可用。

请合并此修复，让仓库的 Star 趋势重新正常展示。