### PR TITLE
fix: avoid redundant restarts after subscription updates

### DIFF
--- a/Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/ClashBar/Resources/Localization/en.lproj/Localizable.strings
@@ -363,6 +363,8 @@
 "log.proxy_export.copied" = "Proxy export command copied";
 "log.logs.copied_all" = "Copied all logs (%d entries)";
 "log.config.changed_restart" = "Config changed, restarting core";
+"log.config.remote.restart_required" = "Subscription changed controller settings, restarting core";
+"log.config.remote.hot_reload_fallback_restart" = "Subscription hot reload failed; restarting core: %@";
 "log.providers.fetch_proxy_failed" = "Providers refresh: fetch proxy providers failed: %@";
 "log.providers.fetch_rule_failed" = "Providers refresh: fetch rule providers failed: %@";
 "log.providers.config_reload_success" = "Providers refresh: config force reload success";

--- a/Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Sources/ClashBar/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -365,6 +365,8 @@
 "log.proxy_export.copied" = "已复制代理导出命令";
 "log.logs.copied_all" = "已复制全部日志（%d 条）";
 "log.config.changed_restart" = "配置已变更，正在重启内核";
+"log.config.remote.restart_required" = "订阅中的控制器设置已变更，正在重启内核";
+"log.config.remote.hot_reload_fallback_restart" = "订阅热重载失败，正在回退为完整重启：%@";
 "log.providers.fetch_proxy_failed" = "Providers 刷新: 获取代理提供者失败: %@";
 "log.providers.fetch_rule_failed" = "Providers 刷新: 获取规则提供者失败: %@";
 "log.providers.config_reload_success" = "Providers 刷新: 强制重载配置成功";

--- a/Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift
@@ -27,6 +27,21 @@ extension AppViewModel {
         self.pendingConfigChangeRestart = false
     }
 
+    /// Records an app-owned config mutation before the main actor can process its
+    /// filesystem event. The caller remains responsible for applying that change.
+    func synchronizeConfigDirectoryMonitorSnapshot(for fileURL: URL) {
+        let fileName = fileURL.lastPathComponent
+        let signature = Self.configFileSignatureSnapshot(for: [fileURL])[fileName]
+        self.configFileSignatureSnapshot[fileName] = signature
+    }
+
+    /// Falls back to the monitor's validated restart path when a config update
+    /// arrives while another core transition is still in progress.
+    func deferConfigRestartUntilCoreIsIdle() {
+        self.pendingConfigChangeRestart = true
+        self.scheduleConfigDirectoryRefresh(delayNanoseconds: 500_000_000)
+    }
+
     private func scheduleConfigDirectoryRefresh(delayNanoseconds: UInt64 = 350_000_000) {
         self.configDirectoryDebounceTask?.cancel()
         self.configDirectoryDebounceTask = Task { [weak self] in

--- a/Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+ConfigMonitoring.swift
@@ -35,13 +35,6 @@ extension AppViewModel {
         self.configFileSignatureSnapshot[fileName] = signature
     }
 
-    /// Falls back to the monitor's validated restart path when a config update
-    /// arrives while another core transition is still in progress.
-    func deferConfigRestartUntilCoreIsIdle() {
-        self.pendingConfigChangeRestart = true
-        self.scheduleConfigDirectoryRefresh(delayNanoseconds: 500_000_000)
-    }
-
     private func scheduleConfigDirectoryRefresh(delayNanoseconds: UInt64 = 350_000_000) {
         self.configDirectoryDebounceTask?.cancel()
         self.configDirectoryDebounceTask = Task { [weak self] in

--- a/Sources/ClashBar/ViewModels/AppViewModel+RemoteConfig.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+RemoteConfig.swift
@@ -41,7 +41,7 @@ extension AppViewModel {
         do {
             let userAgent = await remoteSubscriptionUserAgent()
             let data = try await downloadRemoteConfigData(from: remoteURL, userAgent: userAgent)
-            try writeConfigData(data, to: targetURL)
+            let change = try self.writeRemoteConfigDataIfChanged(data, to: targetURL)
 
             let subscription = RemoteConfigSubscription(
                 urlString: remoteURL.absoluteString,
@@ -52,10 +52,7 @@ extension AppViewModel {
             let message = tr("log.config.import_remote.success", fileName)
             appendLog(level: "info", message: message)
 
-            if existsAlready, self.shouldAutoReloadCurrentConfig(updatedFileNames: [fileName]) {
-                await self.reloadConfig()
-            }
-
+            await self.applyRemoteConfigChange(change, fileName: fileName)
             self.presentRemoteConfigImportResultAlert(success: true, message: message)
         } catch {
             let message = tr("log.config.import_remote.failed", fileName, error.localizedDescription)
@@ -75,8 +72,9 @@ extension AppViewModel {
         }
 
         let userAgent = await remoteSubscriptionUserAgent()
-        var updatedFileNames: Set<String> = []
+        var succeededCount = 0
         var failedCount = 0
+        var changedConfigs: [String: RemoteConfigFileChange] = [:]
 
         for fileName in subscriptions.keys.sorted() {
             guard let sub = subscriptions[fileName],
@@ -104,9 +102,12 @@ extension AppViewModel {
                 else {
                     continue
                 }
-                try self.writeConfigData(data, to: targetURL)
+                let change = try self.writeRemoteConfigDataIfChanged(data, to: targetURL)
                 self.remoteConfigSubscriptions[fileName] = refreshedSubscription
-                updatedFileNames.insert(fileName)
+                succeededCount += 1
+                if change.contentsChanged {
+                    changedConfigs[fileName] = change
+                }
             } catch {
                 guard let refreshedSubscription = self.checkedRemoteConfigSubscription(
                     for: fileName,
@@ -125,10 +126,11 @@ extension AppViewModel {
 
         self.persistRemoteConfigSubscriptions()
         self.refreshConfigStateAfterMutation()
-        appendLog(level: "info", message: tr("log.config.remote.update_summary", updatedFileNames.count, failedCount))
+        appendLog(level: "info", message: tr("log.config.remote.update_summary", succeededCount, failedCount))
 
-        if self.shouldAutoReloadCurrentConfig(updatedFileNames: updatedFileNames) {
-            await self.reloadConfig()
+        let selectedFileName = self.selectedConfigName
+        if let selectedConfigChange = changedConfigs[selectedFileName] {
+            await self.applyRemoteConfigChange(selectedConfigChange, fileName: selectedFileName)
         }
     }
 
@@ -277,15 +279,11 @@ extension AppViewModel {
                 return
             }
             let targetURL = configDirectory.appendingPathComponent(fileName, isDirectory: false)
-            try self.writeConfigData(data, to: targetURL)
+            let change = try self.writeRemoteConfigDataIfChanged(data, to: targetURL)
 
             self.remoteConfigSubscriptions[fileName] = refreshedSubscription
             self.persistRemoteConfigSubscriptions()
-            self.refreshConfigStateAfterMutation()
-
-            if self.shouldAutoReloadCurrentConfig(updatedFileNames: [fileName]) {
-                await self.reloadConfig()
-            }
+            await self.applyRemoteConfigChange(change, fileName: fileName)
 
             self.setRemoteConfigMenuState(
                 for: fileName,
@@ -365,6 +363,134 @@ extension AppViewModel {
 
     func writeConfigData(_ data: Data, to targetURL: URL) throws {
         try configRepository.writeConfigData(data, to: targetURL)
+    }
+
+    private struct RemoteConfigFileChange {
+        let contentsChanged: Bool
+        let requiresFullRestart: Bool
+
+        static let unchanged = RemoteConfigFileChange(contentsChanged: false, requiresFullRestart: false)
+    }
+
+    /// Compares downloaded bytes before validation and atomic replacement. For a
+    /// changed file, update the monitor snapshot synchronously so this app-owned
+    /// write is applied exactly once by `applyRemoteConfigChange` below.
+    private func writeRemoteConfigDataIfChanged(
+        _ data: Data,
+        to targetURL: URL) throws -> RemoteConfigFileChange
+    {
+        let existingData = try? Data(contentsOf: targetURL)
+        if existingData == data {
+            return .unchanged
+        }
+
+        let requiresFullRestart = Self.remoteConfigRequiresFullRestart(
+            previous: existingData,
+            updated: data)
+        try self.writeConfigData(data, to: targetURL)
+        self.refreshConfigStateAfterMutation()
+        self.synchronizeConfigDirectoryMonitorSnapshot(for: targetURL)
+        return RemoteConfigFileChange(
+            contentsChanged: true,
+            requiresFullRestart: requiresFullRestart)
+    }
+
+    private func applyRemoteConfigChange(_ change: RemoteConfigFileChange, fileName: String) async {
+        guard change.contentsChanged else { return }
+        guard self.shouldAutoReloadCurrentConfig(updatedFileNames: [fileName]) else { return }
+
+        guard !self.isCoreActionProcessing else {
+            self.deferConfigRestartUntilCoreIsIdle()
+            return
+        }
+        guard let selectedConfig = self.configRepository.selectedConfig,
+              selectedConfig.lastPathComponent == fileName
+        else { return }
+
+        if change.requiresFullRestart {
+            guard self.selectedConfigName == fileName else { return }
+            self.appendLog(level: "info", message: self.tr("log.config.remote.restart_required"))
+            // restartCore validates the new file before stopping the running core.
+            await self.restartCore(trigger: .configSwitch)
+            return
+        }
+
+        let configPath = selectedConfig.path
+        guard await self.validateConfigBeforeCoreLaunch(configPath: configPath) else { return }
+        guard self.selectedConfigName == fileName else { return }
+
+        let actionName = self.tr("log.action_name.reload_config")
+        let expectedTunEnabled = self.isTunEnabled
+        do {
+            self.ensureAPIClient()
+            try await self.clientOrThrow().requestNoResponse(.putConfigs(force: true))
+            try await self.restoreTunAfterConfigReloadIfNeeded(expectedEnabled: expectedTunEnabled)
+            self.appendLog(level: "info", message: self.tr("log.action.success", actionName))
+        } catch {
+            self.appendLog(
+                level: "warning",
+                message: self.tr("log.config.remote.hot_reload_fallback_restart", error.localizedDescription))
+            await self.restartCore(trigger: .configSwitch)
+        }
+    }
+
+    /// Mihomo's config API updates runtime components, but it does not recreate
+    /// the external-controller server. A change to one of these top-level route
+    /// sections must therefore be applied by starting a new core process.
+    private nonisolated static func remoteConfigRequiresFullRestart(
+        previous: Data?,
+        updated: Data) -> Bool
+    {
+        guard let previous,
+              let previousSections = self.mihomoStartupSectionFingerprint(in: previous),
+              let updatedSections = self.mihomoStartupSectionFingerprint(in: updated)
+        else {
+            return true
+        }
+        return previousSections != updatedSections
+    }
+
+    private nonisolated static func mihomoStartupSectionFingerprint(in data: Data) -> [String: String]? {
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        let keys: Set<String> = [
+            "external-controller",
+            "external-controller-cors",
+            "external-controller-pipe",
+            "external-controller-routing-mark",
+            "external-controller-tls",
+            "external-controller-unix",
+            "external-doh-server",
+            "external-ui",
+            "external-ui-name",
+            "external-ui-url",
+            "secret",
+            "tls",
+        ]
+        var sections: [String: String] = [:]
+        var activeKey: String?
+        var activeLines: [String] = []
+
+        func commitSection() {
+            guard let activeKey else { return }
+            sections[activeKey] = activeLines.joined(separator: "\n")
+        }
+
+        for line in text.components(separatedBy: .newlines) {
+            if let first = line.first, !first.isWhitespace,
+               !line.hasPrefix("#"),
+               let colon = line.firstIndex(of: ":")
+            {
+                commitSection()
+                let rawKey = String(line[..<colon]).trimmingCharacters(in: .whitespaces)
+                let key = rawKey.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                activeKey = keys.contains(key) ? key : nil
+                activeLines = activeKey == nil ? [] : [line.trimmingCharacters(in: .whitespaces)]
+            } else if activeKey != nil {
+                activeLines.append(line.trimmingCharacters(in: .whitespaces))
+            }
+        }
+        commitSection()
+        return sections
     }
 
     func confirmOverwriteConfig(named fileName: String) -> Bool {

--- a/Sources/ClashBar/ViewModels/AppViewModel+RemoteConfig.swift
+++ b/Sources/ClashBar/ViewModels/AppViewModel+RemoteConfig.swift
@@ -41,7 +41,7 @@ extension AppViewModel {
         do {
             let userAgent = await remoteSubscriptionUserAgent()
             let data = try await downloadRemoteConfigData(from: remoteURL, userAgent: userAgent)
-            let change = try self.writeRemoteConfigDataIfChanged(data, to: targetURL)
+            let change = try await self.writeRemoteConfigDataIfChanged(data, to: targetURL)
 
             let subscription = RemoteConfigSubscription(
                 urlString: remoteURL.absoluteString,
@@ -102,7 +102,7 @@ extension AppViewModel {
                 else {
                     continue
                 }
-                let change = try self.writeRemoteConfigDataIfChanged(data, to: targetURL)
+                let change = try await self.writeRemoteConfigDataIfChanged(data, to: targetURL)
                 self.remoteConfigSubscriptions[fileName] = refreshedSubscription
                 succeededCount += 1
                 if change.contentsChanged {
@@ -125,7 +125,7 @@ extension AppViewModel {
         }
 
         self.persistRemoteConfigSubscriptions()
-        self.refreshConfigStateAfterMutation()
+        self.refreshRemoteConfigMenuStates()
         appendLog(level: "info", message: tr("log.config.remote.update_summary", succeededCount, failedCount))
 
         let selectedFileName = self.selectedConfigName
@@ -279,7 +279,7 @@ extension AppViewModel {
                 return
             }
             let targetURL = configDirectory.appendingPathComponent(fileName, isDirectory: false)
-            let change = try self.writeRemoteConfigDataIfChanged(data, to: targetURL)
+            let change = try await self.writeRemoteConfigDataIfChanged(data, to: targetURL)
 
             self.remoteConfigSubscriptions[fileName] = refreshedSubscription
             self.persistRemoteConfigSubscriptions()
@@ -365,7 +365,7 @@ extension AppViewModel {
         try configRepository.writeConfigData(data, to: targetURL)
     }
 
-    private struct RemoteConfigFileChange {
+    private struct RemoteConfigFileChange: Sendable {
         let contentsChanged: Bool
         let requiresFullRestart: Bool
 
@@ -377,32 +377,73 @@ extension AppViewModel {
     /// write is applied exactly once by `applyRemoteConfigChange` below.
     private func writeRemoteConfigDataIfChanged(
         _ data: Data,
-        to targetURL: URL) throws -> RemoteConfigFileChange
+        to targetURL: URL) async throws -> RemoteConfigFileChange
     {
-        let existingData = try? Data(contentsOf: targetURL)
-        if existingData == data {
+        let change = try await Task.detached(priority: .utility) {
+            let existingData: Data?
+            if FileManager.default.fileExists(atPath: targetURL.path) {
+                existingData = try Data(contentsOf: targetURL)
+            } else {
+                existingData = nil
+            }
+
+            guard existingData != data else {
+                return RemoteConfigFileChange.unchanged
+            }
+            return RemoteConfigFileChange(
+                contentsChanged: true,
+                requiresFullRestart: Self.remoteConfigRequiresFullRestart(
+                    previous: existingData,
+                    updated: data))
+        }.value
+        guard change.contentsChanged else {
             return .unchanged
         }
 
-        let requiresFullRestart = Self.remoteConfigRequiresFullRestart(
-            previous: existingData,
-            updated: data)
+        try await self.validateRemoteConfigData(data, targetURL: targetURL)
         try self.writeConfigData(data, to: targetURL)
-        self.refreshConfigStateAfterMutation()
         self.synchronizeConfigDirectoryMonitorSnapshot(for: targetURL)
-        return RemoteConfigFileChange(
-            contentsChanged: true,
-            requiresFullRestart: requiresFullRestart)
+        return change
+    }
+
+    /// Validates the candidate beside the destination so Mihomo resolves relative
+    /// provider paths against the same working directory. Hidden files are ignored
+    /// by the config directory scanner and are always removed after validation.
+    private func validateRemoteConfigData(_ data: Data, targetURL: URL) async throws {
+        let candidateURL = targetURL.deletingLastPathComponent().appendingPathComponent(
+            ".clashbar-validation-\(UUID().uuidString).\(targetURL.pathExtension)",
+            isDirectory: false)
+        try await Task.detached(priority: .utility) {
+            try data.write(to: candidateURL, options: .atomic)
+        }.value
+        defer { try? FileManager.default.removeItem(at: candidateURL) }
+
+        guard let details = await self.configValidationFailureDetails(configPath: candidateURL.path) else {
+            return
+        }
+        throw NSError(
+            domain: "ClashBar.RemoteConfigValidation",
+            code: 422,
+            userInfo: [
+                NSLocalizedDescriptionKey: self.tr(
+                    "log.config.validate_failed",
+                    targetURL.lastPathComponent,
+                    details),
+            ])
     }
 
     private func applyRemoteConfigChange(_ change: RemoteConfigFileChange, fileName: String) async {
         guard change.contentsChanged else { return }
         guard self.shouldAutoReloadCurrentConfig(updatedFileNames: [fileName]) else { return }
 
-        guard !self.isCoreActionProcessing else {
-            self.deferConfigRestartUntilCoreIsIdle()
-            return
+        while self.isCoreActionProcessing {
+            do {
+                try await Task.sleep(for: .milliseconds(250))
+            } catch {
+                return
+            }
         }
+        guard self.shouldAutoReloadCurrentConfig(updatedFileNames: [fileName]) else { return }
         guard let selectedConfig = self.configRepository.selectedConfig,
               selectedConfig.lastPathComponent == fileName
         else { return }
@@ -415,8 +456,6 @@ extension AppViewModel {
             return
         }
 
-        let configPath = selectedConfig.path
-        guard await self.validateConfigBeforeCoreLaunch(configPath: configPath) else { return }
         guard self.selectedConfigName == fileName else { return }
 
         let actionName = self.tr("log.action_name.reload_config")
@@ -475,22 +514,66 @@ extension AppViewModel {
             sections[activeKey] = activeLines.joined(separator: "\n")
         }
 
-        for line in text.components(separatedBy: .newlines) {
+        for rawLine in text.components(separatedBy: .newlines) {
+            guard let line = self.normalizedYAMLLine(rawLine) else { continue }
             if let first = line.first, !first.isWhitespace,
-               !line.hasPrefix("#"),
                let colon = line.firstIndex(of: ":")
             {
                 commitSection()
                 let rawKey = String(line[..<colon]).trimmingCharacters(in: .whitespaces)
                 let key = rawKey.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
                 activeKey = keys.contains(key) ? key : nil
-                activeLines = activeKey == nil ? [] : [line.trimmingCharacters(in: .whitespaces)]
+                activeLines = activeKey == nil ? [] : [line]
             } else if activeKey != nil {
-                activeLines.append(line.trimmingCharacters(in: .whitespaces))
+                activeLines.append(line)
             }
         }
         commitSection()
         return sections
+    }
+
+    /// Removes YAML comments without treating a `#` inside a quoted or plain
+    /// non-whitespace-delimited scalar as a comment. Leading indentation remains
+    /// intact because it is semantically significant in YAML.
+    private nonisolated static func normalizedYAMLLine(_ line: String) -> String? {
+        let characters = Array(line)
+        var inSingleQuotes = false
+        var inDoubleQuotes = false
+        var isEscapingDoubleQuote = false
+        var commentStart: Int?
+
+        for index in characters.indices {
+            let character = characters[index]
+            if inDoubleQuotes, character == "\\", !isEscapingDoubleQuote {
+                isEscapingDoubleQuote = true
+                continue
+            }
+            if character == "\"", !inSingleQuotes, !isEscapingDoubleQuote {
+                inDoubleQuotes.toggle()
+            } else if character == "'", !inDoubleQuotes {
+                inSingleQuotes.toggle()
+            } else if character == "#", !inSingleQuotes, !inDoubleQuotes,
+                      index == characters.startIndex || characters[characters.index(before: index)].isWhitespace
+            {
+                commentStart = index
+                break
+            }
+            isEscapingDoubleQuote = false
+        }
+
+        let content = String(characters[..<(commentStart ?? characters.endIndex)])
+        let normalized = self.trimmingTrailingWhitespace(content)
+        return normalized.trimmingCharacters(in: .whitespaces).isEmpty ? nil : normalized
+    }
+
+    private nonisolated static func trimmingTrailingWhitespace(_ value: String) -> String {
+        var endIndex = value.endIndex
+        while endIndex > value.startIndex {
+            let previousIndex = value.index(before: endIndex)
+            guard value[previousIndex].isWhitespace else { break }
+            endIndex = previousIndex
+        }
+        return String(value[..<endIndex])
     }
 
     func confirmOverwriteConfig(named fileName: String) -> Bool {


### PR DESCRIPTION
默认每6小时检查订阅的配置文件后，会自动重启mihomo，导致网络闪断，原因是下载订阅的配置文件后会直接覆盖原文件，导致文件innode发生变化，不管内容是否有变化都会触发重启mihomo。

优化后的订阅配置文件检查和处理流程：

下载订阅
  ↓
与本地文件按字节比较
  ↓
[内容相同]
  ├─ 只更新检查时间
  ├─ 不执行配置校验
  ├─ 不写入文件
  └─ 不触发配置加载

[内容不同]
  ↓
校验新配置
  ↓
原子写入配置文件
  ↓
调用 PUT /configs?force=true 进行热重载
  ↓
[热重载成功]
  └─ 处理结束，不重启进程

[热重载失败 / API 不可用]
  └─ 根据具体错误判断是否回退为完整重启


应用自身写入配置文件时，屏蔽本次写入产生的文件监听事件。

需要完整重启的特殊情况，可以进一步判断：

  external-controller*
  secret
  控制器 TLS
  启动参数或配置文件路径

  普通机场订阅一般只是节点、代理组和规则，因此绝大多数六小时更新都可以只热重载。这样不会更换 PID，也不会无条件断开所有现有连接。